### PR TITLE
Add privacy tests for non contributor user [QA-79]

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -14,29 +14,27 @@ from base.exceptions import HttpError, PageException
 class BasePage(BaseElement):
     url = None
 
-    cas_identity = Locator(By.ID, 'cas')
-
     def __init__(self, driver, verify=False):
         super().__init__(driver)
 
         if verify:
             self.check_page()
 
-    def goto(self, expect_login_redirect=False):
+    def goto(self, expect_redirect_to=None):
         """Navigate to a page based on its `url` attribute
         and confirms you are on the expected page.
 
-        If you are testing permissions, you may want to navigate to a page that
-        requires authentication as a logged out user. In this case you will be
-        redirected to CAS. You can set `expect_login_redirect` to True to verify
-        you are on the login page.
+        If you are not actually expecting to end up on the page you attempt to `goto`
+        (for example when testing permissions) you can set `expect_redirect_to` equal to
+        any BasePage class and it will be verified you wind up on that page instead.
         """
-        self.driver.get(self.url)
-        if expect_login_redirect:
 
-            current_url = self.driver.current_url
-            if not (self.cas_identity.present() and self.url in current_url):
-                raise PageException('Unexpected page structure: `{}`'.format(self.driver.current_url))
+        self.driver.get(self.url)
+
+        if expect_redirect_to:
+            if self.url not in self.driver.current_url:
+                raise PageException('Unexpected url structure: `{}`'.format(self.driver.current_url))
+            expect_redirect_to(self.driver, verify=True)
         else:
             self.check_page()
 

--- a/pages/login.py
+++ b/pages/login.py
@@ -9,7 +9,7 @@ from pages.base import BasePage, OSFBasePage
 class LoginPage(BasePage):
     url = settings.OSF_HOME + '/login'
 
-    identity = Locator(By.CSS_SELECTOR, '#cas #forgot-password', settings.LONG_TIMEOUT)
+    identity = Locator(By.CSS_SELECTOR, '#cas', settings.LONG_TIMEOUT)
     username_input = Locator(By.ID, 'username')
     password_input = Locator(By.ID, 'password')
     submit_button = Locator(By.NAME, 'submit')

--- a/pages/project.py
+++ b/pages/project.py
@@ -8,6 +8,7 @@ from base.locators import Locator, ComponentLocator
 
 
 class ProjectPage(GuidBasePage):
+
     identity = Locator(By.CSS_SELECTOR, '#overview > nav#projectSubnav')
     title = Locator(By.ID, 'nodeTitleEditable', settings.LONG_TIMEOUT)
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
@@ -21,6 +22,10 @@ class ProjectPage(GuidBasePage):
     # Components
     file_widget = ComponentLocator(FileWidget)
     log_widget = ComponentLocator(LogWidget)
+
+class RequestAccessPage(GuidBasePage):
+
+    identity = Locator(By.CSS_SELECTOR, '#requestAccessPrivateScope')
 
 
 class MyProjectsPage(OSFBasePage):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import settings
 from api import osf_api
 from pythosf import client
 from pages.login import logout, safe_login
+from pages.project import ProjectPage
 from utils import launch_driver
 
 
@@ -71,6 +72,10 @@ def default_project(session):
         project = osf_api.create_project(session, title='OSF Test Project')
         yield project
         project.delete()
+
+@pytest.fixture
+def default_project_page(driver, default_project):
+    return ProjectPage(driver, guid=default_project.id)
 
 @pytest.fixture
 def public_project(session):


### PR DESCRIPTION
## Purpose
Add privacy tests for different users 


## Summary of Changes
- Added privacy tests for user two.
- Replaced `expect_login_redirect` flag on BasePage's `goto` with the more generic `expect_redirect_to`.


## Testing Changes Moving Forward
From now on, one can choose what page is expected (as it is possible for there to be a redirect or an error) when you `goto` a page. The page is still expected to have the requested URL within it.


## Ticket

https://openscience.atlassian.net/browse/QA-79
