### PR TITLE
Check that custom institution URL is maintained

### DIFF
--- a/tests/test_institutions.py
+++ b/tests/test_institutions.py
@@ -13,3 +13,4 @@ class TestCustomDomains:
         #TODO: Add check for institution name
         driver.get(domain)
         InstitutionsLandingPage(driver, verify=True)
+        assert domain in driver.current_url


### PR DESCRIPTION
## Purpose
Since https://openscience.atlassian.net/browse/PLAT-1108 specifies that we should not redirect away from our custom institution domains, let's update our smoke tests to check that as well.


## Summary of Changes
Add confirmation we are in fact on the custom domain.


## Testing Changes Moving Forward
None


## Ticket
None
