### PR TITLE
Add core test for analytics page [QA-70]

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -37,3 +37,10 @@ class MyProjectsPage(OSFBasePage):
 class InstitutionsLandingPage(OSFBasePage):
 
     identity = Locator(By.CSS_SELECTOR, '#fileBrowser > div.db-header.row > div.db-buttonRow.col-xs-12.col-sm-4.col-lg-3 > div > input')
+
+class AnalyticsPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/analytics/'
+
+    identity = Locator(By.CSS_SELECTOR, '._Counts_1mhar6')
+    private_project_message = Locator(By.CSS_SELECTOR, '._PrivateProject_1mhar6')
+    disabled_chart = Locator(By.CSS_SELECTOR, '._Chart_1hff7g _Blurred_1hff7g')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,7 @@ import pytest
 import markers
 import settings
 from api import osf_api
-from pages.project import ProjectPage, RequestAccessPage
+from pages.project import ProjectPage, RequestAccessPage, AnalyticsPage
 from pages.login import LoginPage, login, logout
 
 @pytest.fixture()
@@ -93,3 +93,12 @@ class TestProjectDetailLoggedOut:
     def test_is_private(self, driver, default_project_page):
         # Verify that a logged out user cannot see the project
         default_project_page.goto(expect_redirect_to=LoginPage)
+
+
+class TestAnalyticsPage:
+
+    @markers.core_functionality
+    def private_project(self, default_project):
+        analytics_page = AnalyticsPage(default_project.id)
+        assert analytics_page.private_project_message.present()
+        assert analytics_page.disabled_chart.present()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Add core test for analytics page.


## Summary of Changes
Add very basic test for the analytics page of a private project.


## Testing Changes Moving Forward
None

## Ticket

https://openscience.atlassian.net/browse/QA-70
