### PR TITLE
Add forks page core functionality test [QA-58]

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -60,3 +60,16 @@ class AnalyticsPage(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '._Counts_1mhar6')
     private_project_message = Locator(By.CSS_SELECTOR, '._PrivateProject_1mhar6')
     disabled_chart = Locator(By.CSS_SELECTOR, '._Chart_1hff7g _Blurred_1hff7g')
+
+
+class ForksPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/forks/'
+
+    identity = Locator(By.CSS_SELECTOR, '._Forks_1xlord')
+    new_fork_button = Locator(By.CSS_SELECTOR, '._Forks__new-fork_1xlord .btn-success')
+    create_fork_modal_button = Locator(By.CSS_SELECTOR, '.modal-footer .btn-info')
+    cancel_modal_button = Locator(By.CSS_SELECTOR, '.modal-footer .btn-default')
+    info_toast = Locator(By.CSS_SELECTOR, '.toast-info')
+
+    # Group Locators
+    listed_forks = GroupLocator(By.CSS_SELECTOR, '.list-group-item')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,7 @@ import pytest
 import markers
 import settings
 from api import osf_api
-from pages.project import ProjectPage, RequestAccessPage, AnalyticsPage
+from pages.project import ProjectPage, RequestAccessPage, AnalyticsPage, ForksPage
 from pages.login import LoginPage, login, logout
 
 @pytest.fixture()
@@ -93,6 +93,26 @@ class TestProjectDetailLoggedOut:
     def test_is_private(self, driver, default_project_page):
         # Verify that a logged out user cannot see the project
         default_project_page.goto(expect_redirect_to=LoginPage)
+
+
+class TestForksPage:
+
+    @pytest.fixture()
+    def forks_page(self, driver, default_project):
+        forks_page = ForksPage(driver, guid=default_project.id)
+        forks_page.goto()
+        return forks_page
+
+    @markers.dont_run_on_prod
+    @markers.core_functionality
+    def test_create_fork(self, must_be_logged_in, forks_page):
+        assert len(forks_page.listed_forks) == 0
+        forks_page.new_fork_button.click()
+        forks_page.create_fork_modal_button.click()
+        forks_page.info_toast.present()
+        forks_page.reload()
+        forks_page.verify()
+        assert len(forks_page.listed_forks) == 1
 
 
 class TestAnalyticsPage:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose

Add a core functionality test for the forks page.

## Summary of Changes
- Add forks page page object
- Add test that creates a fork from the forks page.

## Testing Changes Moving Forward

None

## Ticket

https://openscience.atlassian.net/browse/QA-58
