### PR TITLE
Add create user test for register page [QA-75]

### DIFF
--- a/components/generic.py
+++ b/components/generic.py
@@ -1,0 +1,22 @@
+import settings
+
+from time import sleep
+from selenium.webdriver.common.by import By
+from base.locators import Locator, BaseElement
+
+
+class SignUpForm(BaseElement):
+    name_input = Locator(By.NAME, 'fullName')
+    email_one_input = Locator(By.NAME, 'email1')
+    email_two_input = Locator(By.NAME, 'email2')
+    password_input = Locator(By.NAME, 'password')
+    terms_of_service_checkbox = Locator(By.NAME, 'acceptedTermsOfService')
+    sign_up_button = Locator(By.CSS_SELECTOR, '[data-test-sign-up-button]')
+    registration_success = Locator(By.CSS_SELECTOR, '.ext-success', settings.LONG_TIMEOUT)
+
+    def click_recaptcha(self):
+        self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
+        Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-checkmark').get_element(self.driver, 'capcha').click()
+        self.driver.switch_to.default_content()
+        #TODO: Replace with an expected condition that checks if aria-checked="true"
+        sleep(2)

--- a/pages/base.py
+++ b/pages/base.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 
 from components.navbars import HomeNavbar
-from base.locators import BaseElement, ComponentLocator, Locator
+from base.locators import BaseElement, ComponentLocator
 from base.exceptions import HttpError, PageException
 
 
@@ -67,12 +67,6 @@ class BasePage(BaseElement):
         # Note: If you close the browser too quickly, the drag/drop may not go through
         sleep(1)
 
-    def click_recaptcha(self):
-        self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
-        Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-checkmark').get_element(self.driver, 'capcha').click()
-        self.driver.switch_to.default_content()
-        #TODO: Replace with an expected condition that checks if aria-checked="true"
-        sleep(2)
 
 class OSFBasePage(BasePage):
     """

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -3,6 +3,7 @@ import settings
 from selenium.webdriver.common.by import By
 
 from pages.base import OSFBasePage
+from components.generic import SignUpForm
 from components.navbars import EmberNavbar
 from base.locators import Locator, ComponentLocator
 
@@ -10,17 +11,9 @@ from base.locators import Locator, ComponentLocator
 class LandingPage(OSFBasePage):
     identity = Locator(By.ID, 'home-hero', settings.LONG_TIMEOUT)
 
-    name_input = Locator(By.NAME, 'fullName')
-    email_one_input = Locator(By.NAME, 'email1')
-    email_two_input = Locator(By.NAME, 'email2')
-    password_input = Locator(By.NAME, 'password')
-    terms_of_service_checkbox = Locator(By.NAME, 'acceptedTermsOfService')
-    sign_up_button = Locator(By.CSS_SELECTOR, '._SignUpForm_3ntsx4 .btn-success')
-    registration_success = Locator(By.CSS_SELECTOR, '.ext-success', settings.LONG_TIMEOUT)
-
     # Components
     navbar = ComponentLocator(EmberNavbar)
-
+    sign_up_form = ComponentLocator(SignUpForm)
 
 class LegacyLandingPage(OSFBasePage):
     waffle_override = {'ember_home_page': LandingPage}

--- a/pages/register.py
+++ b/pages/register.py
@@ -1,14 +1,18 @@
 import settings
 
-from base.locators import Locator
 from selenium.webdriver.common.by import By
-from pages.base import OSFBasePage
 
+from pages.base import OSFBasePage
+from components.generic import SignUpForm
+from base.locators import Locator, ComponentLocator
 
 class EmberRegisterPage(OSFBasePage):
     url = settings.OSF_HOME + '/register'
 
     identity = Locator(By.CSS_SELECTOR, '._sign-up-container_19kgff')
+
+    # Components
+    sign_up_form = ComponentLocator(SignUpForm)
 
 
 class RegisterPage(OSFBasePage):

--- a/tests/generic.py
+++ b/tests/generic.py
@@ -1,0 +1,30 @@
+import pytest
+import markers
+import settings
+
+class CreateUserMixin():
+    """Mixin used to inject user creation test
+    """
+    @pytest.fixture()
+    def page(self, driver):
+        raise NotImplementedError()
+
+    @markers.dont_run_on_prod
+    @pytest.mark.skipif(settings.TEST, reason='There is a real recapcha on test. Robots cannot create users there.')
+    @markers.core_functionality
+    def test_create_user(self, page, fake):
+
+        name = fake.name()
+        email = settings.NEW_USER_EMAIL.format(''.join(name.split()))  # Add name with no spaces to end of email
+        password = fake.sentence()
+
+        page.scroll_into_view(page.sign_up_form.sign_up_button.element)
+
+        page.sign_up_form.name_input.send_keys(name)
+        page.sign_up_form.email_one_input.send_keys(email)
+        page.sign_up_form.email_two_input.send_keys(email)
+        page.sign_up_form.password_input.send_keys(password)
+        page.sign_up_form.terms_of_service_checkbox.click()
+        page.sign_up_form.click_recaptcha()
+        page.sign_up_form.sign_up_button.click()
+        assert page.sign_up_form.registration_success.present()

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -1,7 +1,7 @@
 import pytest
 import markers
-import settings
 
+from tests.generic import CreateUserMixin
 from pages.landing import LandingPage, RegisteredReportsLandingPage
 
 @pytest.fixture()
@@ -11,27 +11,11 @@ def landing_page(driver):
     return landing_page
 
 
-class TestLandingPage:
+class TestLandingPage(CreateUserMixin):
 
-    @markers.dont_run_on_prod
-    @pytest.mark.skipif(settings.TEST, reason='There is a real recapcha on test. Robots cannot create users there.')
-    @markers.core_functionality
-    def test_create_user(self, landing_page, fake):
-
-        name = fake.name()
-        email = settings.NEW_USER_EMAIL.format(''.join(name.split()))  # Add name with no spaces to end of email
-        password = fake.sentence()
-
-        landing_page.scroll_into_view(landing_page.sign_up_button.element)
-
-        landing_page.name_input.send_keys(name)
-        landing_page.email_one_input.send_keys(email)
-        landing_page.email_two_input.send_keys(email)
-        landing_page.password_input.send_keys(password)
-        landing_page.terms_of_service_checkbox.click()
-        landing_page.click_recaptcha()
-        landing_page.sign_up_button.click()
-        assert landing_page.registration_success.present()
+    @pytest.fixture()
+    def page(self, landing_page):
+        return landing_page
 
 
 class TestRegisteredReportsLandingPage:

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tests.generic import CreateUserMixin
+from pages.register import RegisterPage
+
+@pytest.fixture()
+def register_page(driver):
+    register_page = RegisterPage(driver)
+    register_page.goto()
+    return register_page
+
+
+class TestRegisterPage(CreateUserMixin):
+
+    @pytest.fixture()
+    def page(self, register_page):
+        return register_page


### PR DESCRIPTION
## Purpose
Add a user creation test for osf.io/register.

## Summary of Changes
- Create create the `SignUpForm` component to be shared by the landing and register pages.
- Add tests/generic.py to store generic test cases.
- Start running the create user test on the register page (before it only ran on the landing page)


## Testing Changes Moving Forward
Generic tests that are used between different pages can be placed in tests/generic.py.

Note: The generic create user test requires that the `SignUpPage` component is named `sign_up_page` in any page object that wants to run said test. We want to be careful as we move forward with generic tests that there aren't too many assumptions...

## Ticket

https://openscience.atlassian.net/browse/QA-75
