### PR TITLE
Update locators for newly emberized pages

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -51,7 +51,7 @@ class EmberNavbar(HomeNavbar):
     user_dropdown_profile = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(1) > a')
     user_dropdown_support = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(2) > a')
     user_dropdown_settings = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(3) > a')
-    logout_link = Locator(By.CSS_SELECTOR, '._LogOutButton_15bw95')
+    logout_link = Locator(By.CSS_SELECTOR, '[data-test-ad-logout]')
     sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
     donate_link = Locator(By.XPATH, '//a[text()="Donate"]')
 

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -51,7 +51,7 @@ class EmberNavbar(HomeNavbar):
     user_dropdown_profile = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(1) > a')
     user_dropdown_support = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(2) > a')
     user_dropdown_settings = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(3) > a')
-    logout_link = Locator(By.CSS_SELECTOR, '.dropdown-menu.auth-dropdown li:nth-child(4) > a')
+    logout_link = Locator(By.CSS_SELECTOR, '._LogOutButton_15bw95')
     sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
     donate_link = Locator(By.XPATH, '//a[text()="Donate"]')
 

--- a/pages/quickfiles.py
+++ b/pages/quickfiles.py
@@ -26,7 +26,7 @@ class QuickfilesPage(BaseQuickfilesPage, GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '#quickfiles-dropzone')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     upload_button = Locator(By.CSS_SELECTOR, '.dz-upload-button')
-    share_button = Locator(By.CSS_SELECTOR, '#shareButton')
+    share_button = Locator(By.CSS_SELECTOR, '.btn .fa-share-alt')
     view_button = Locator(By.CSS_SELECTOR, '.btn .fa-file-o')
     help_button = Locator(By.CSS_SELECTOR, '.btn .fa-info')
     filter_button = Locator(By.CSS_SELECTOR, '.btn .fa-search')

--- a/pages/support.py
+++ b/pages/support.py
@@ -10,9 +10,3 @@ class SupportPage(OSFBasePage):
     url = settings.OSF_HOME + '/support'
 
     identity = Locator(By.CSS_SELECTOR, '._Support_15i3vw', settings.LONG_TIMEOUT)
-
-
-class LegacySupportPage(OSFBasePage):
-    waffle_override = {'ember_support_page': SupportPage}
-
-    identity = Locator(By.CSS_SELECTOR, 'body > div.watermarked > div > div > h1', settings.LONG_TIMEOUT)

--- a/pages/user.py
+++ b/pages/user.py
@@ -60,12 +60,26 @@ class NotificationsPage(BaseUserSettingsPage):
 
     identity = Locator(By.CSS_SELECTOR, '#notificationSettings')
 
+class EmberDeveloperAppsPage(BaseUserSettingsPage):
+    url = settings.OSF_HOME + '/settings/applications/'
+
+    identity = Locator(By.CSS_SELECTOR, '._Top__explanation_1k7ky0')
+
 class DeveloperAppsPage(BaseUserSettingsPage):
+    waffle_override = {'ember_user_settings_apps_page': EmberDeveloperAppsPage}
+
     url = settings.OSF_HOME + '/settings/applications/'
 
     identity = Locator(By.CSS_SELECTOR, '#applicationListPage')
 
+class EmberPersonalAccessTokenPage(BaseUserSettingsPage):
+    url = settings.OSF_HOME + '/settings/tokens/'
+
+    identity = Locator(By.CSS_SELECTOR, '._Top_1somdw')
+
 class PersonalAccessTokenPage(BaseUserSettingsPage):
+    waffle_override = {'ember_user_settings_tokens_page': EmberPersonalAccessTokenPage}
+
     url = settings.OSF_HOME + '/settings/tokens/'
 
     identity = Locator(By.CSS_SELECTOR, '#personalTokenListPage')

--- a/pages/user.py
+++ b/pages/user.py
@@ -63,7 +63,7 @@ class NotificationsPage(BaseUserSettingsPage):
 class EmberDeveloperAppsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/applications/'
 
-    identity = Locator(By.CSS_SELECTOR, '._Top__explanation_1k7ky0')
+    identity = Locator(By.CSS_SELECTOR, '[data-test-create-app-link]')
 
 class DeveloperAppsPage(BaseUserSettingsPage):
     waffle_override = {'ember_user_settings_apps_page': EmberDeveloperAppsPage}
@@ -75,7 +75,7 @@ class DeveloperAppsPage(BaseUserSettingsPage):
 class EmberPersonalAccessTokenPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/tokens/'
 
-    identity = Locator(By.CSS_SELECTOR, '._Top_1somdw')
+    identity = Locator(By.CSS_SELECTOR, '[data-test-create-token-link]')
 
 class PersonalAccessTokenPage(BaseUserSettingsPage):
     waffle_override = {'ember_user_settings_tokens_page': EmberPersonalAccessTokenPage}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,7 +15,7 @@ class TestSearchPage:
 
     @markers.smoke_test
     @markers.core_functionality
-    def test_search_results_exist(self, driver, search_page):
+    def test_search_results_exist(self, search_page):
         search_page.search_bar.send_keys('*')
         search_page.search_bar.send_keys(Keys.ENTER)
         search_page.loading_indicator.here_then_gone()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose

Small fixes to update failing tests, mostly due to emberization.

## Summary of Changes

Adds better locators and adds waffle overrides to Developer Apps and Personal Access tokens. Fixes locator for share button on Quickfiles. Removes some unused code.

## Testing Changes Moving Forward

If waffle flags are removed, remove waffle overrides.

## Ticket

None
