### PR TITLE
rewrite .env.example to be more descriptive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,77 @@
-"""Example .env.
-"""
+# Sample .env file.  Copy this to .env and modify as desired.  Sample values are defaults, unless
+# surrounded by angle brackets.  Values in angle brackets are examples and have no default.
 
-# Choose server if desired, the default is staging 1
-DOMAIN = 'test'
 
-# User information
-USER_ONE = 'CHANGEME'
-USER_ONE_PASSWORD = 'CHANGEME'
+##### Timeouts #####
 
-USER_TWO = 'CHANGEME'
-USER_TWO_PASSWORD = 'CHANGEME'
+## Configure the wait times of various timeouts in the test suite. All values given in seconds.
 
-# Email used for creaing new users. Email should be in the form email+{}@gmail.com in order to make unique emails.
-NEW_USER_EMAIL = 'CHANGEME'
+# QUICK_TIMEOUT=4
+# TIMEOUT=10
+# LONG_TIMEOUT=30
+# VERY_LONG_TIMEOUT=60
+
+
+##### Driver config #####
+
+## Which browser/software stack to run the tests under.
+
+## DRIVER: which browser to test in.  Valid options are 'Chrome', 'Firefox', 'Remote'
+##   'Chrome' requires that chromedriver is available in $PATH
+##   'Firefox' requires that geckodriver is available in $PATH
+##   'Remote' will run the tests via BrowserStack
+##
+## HEADLESS: Should selenium hide the browser gui as the tests are being run?
+##   True = Hide the gui
+##   False = Show the gui
+##   Not relevant when DRIVER=Remote
+
+# DRIVER=Firefox
+# HEADLESS=False
+
+
+## If DRIVER=Remote (will be run on BrowserStack), then the following apply and are MANDATORY.
+##   TEST_BUILD: This tells BrowserStack which driver to use
+##     Valid options are 'chrome', 'firefox', or 'edge'
+##   BSTACK_USER: BrowserStack username
+##   BSTACK_KEY: BrowserStack api key
+
+# TEST_BUILD=chrome
+# BSTACK_USER=<quality-human>
+# BSTACK_KEY=<meowmeowmeow>
+
+
+##### Testing environment #####
+
+## Where to run the tests
+
+## DOMAIN: On what environment will the tests be executed?
+##   valid options are: 'test', 'stage1', 'stage2', 'stage3', or 'prod'
+## PREFERRED_NODE: When DOMAIN=prod, don't create new projects. Instead, run all tests under
+##   this guid. MANDATORY if DOMAIN=prod. You must manually create a project and add its guid here.
+## EXPECTED_PROVIDERS: Only applies when DOMAIN=prod.  A comma-separated list of storage
+##   providers connected to the PREFERRED_NODE.
+
+# DOMAIN=stage1
+# PREFERRED_NODE=<mst3k>
+# EXPECTED_PROVIDERS=bitbucket,box,dataverse,dropbox,figshare,github,gitlab,googledrive,osfstorage,owncloud,onedrive,s3
+
+
+##### Fixtures #####
+
+## Users: Need to create two users for testing purposes.  Add their logins and passwords here.
+##   NB!!!  In a non-prod environment, all these users' nodes will be deleted during the test.
+##   DO NOT USE a user with projects you care about.
+##
+## USER_ONE: Email address of first test user.  User must already exist on DOMAIN env.
+## USER_ONE_PASSWORD: Password of first test user.
+## USER_TWO: Email address of second test user.  User must already exist on DOMAIN env.
+## USER_TWO_PASSWORD: Password of second test user.
+## NEW_USER_EMAIL: Email address used for new user signup. Email should be in the form
+##   email+{}@gmail.com in order to make unique emails.
+
+# USER_ONE=<foo@example.com>
+# USER_ONE_PASSWORD=<i_fear_penguins>
+# USER_TWO=<bar@example.com>
+# USER_TWO_PASSWORD=<i_fear_polar_beards>
+# NEW_USER_EMAIL=<baz+emailtest@example.com>


### PR DESCRIPTION
## Purpose

Update `.env.example` to document all settings and change a pythonism to a shellism.

## Summary of Changes

* Remove python-style heredocs that don't parse as shell
* Document all setting vars from settings.py
* List options for settings with constrained values

## Testing Changes Moving Forward

Doc-only, no functional changes.

## Ticket

*None*