### PR TITLE
Send keys

### DIFF
--- a/base/locators.py
+++ b/base/locators.py
@@ -99,28 +99,13 @@ class WebElementWrapper:
         self.driver.switch_to.window(self.driver.window_handles[0])
         self.driver.maximize_window()
 
-    def send_keys(self, keys, timeout=settings.TIMEOUT):
-        """Generally use the normal WebElement `send_keys`.
+    def send_keys(self, keys):
+        self.element.send_keys(keys)
 
-        If the browser is IE, send keys until the element has the correct keys or until timeout.
-        Only sends special keystrokes (i.e. ENTER) once.
-        """
-
-        if settings.BUILD != 'msie' or repr(keys).find('\\ue0'):
-            self.element.send_keys(keys)
-        else:
-            existing_keys = self.element.get_attribute('value')
-            sleep(.25)
-            self.element.send_keys(keys)
-
-            try:
-                WebDriverWait(self.driver, timeout).until(
-                    ec.correct_keys_sent(self.element, keys, existing_keys)
-                )
-            except(TimeoutException, StaleElementReferenceException):
-                raise ValueError('Could not get the correct keys to send to {} in IE.'.format(
-                    self.name))
-
+    def send_keys_deliberately(self, keys):
+        """Send keys one at a time to ensure accuracy"""
+        for k in keys:
+            self.element.send_keys(k)
 
 class BaseLocator:
     """Abstract base class from which all Locator classes inherit.

--- a/base/locators.py
+++ b/base/locators.py
@@ -1,6 +1,5 @@
 import settings
 
-from time import sleep
 from base import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -73,7 +73,7 @@ class TestProjectDetailPage:
         project_page.file_widget.filter_button.click()
         for provider in providers:
             project_page.file_widget.filter_input.clear()
-            project_page.file_widget.filter_input.send_keys(provider)
+            project_page.file_widget.filter_input.send_keys_deliberately(provider)
             driver.find_element_by_xpath("//*[contains(text(), '{}')]".format(provider + '.txt'))
 
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Stop test_addon_files_load test from failing due to send keys error.


## Summary of Changes
Add new method for send_keys called send_keys_deliberately, which sends keys one at a time to ensure accuracy.  

Also removed a special send_keys method for IE, since we don't test in IE anymore.


## Testing Changes Moving Forward
None


## Ticket

https://openscience.atlassian.net/browse/QA-
