### PR TITLE
Update embosfed locators for user account settings

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -71,6 +71,7 @@ class ForksPage(GuidBasePage):
     # Group Locators
     listed_forks = GroupLocator(By.CSS_SELECTOR, '.list-group-item')
 
+
 class FilesPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/files/'
 
@@ -81,7 +82,8 @@ class FilesPage(GuidBasePage):
     file_action_buttons = GroupLocator(By.CSS_SELECTOR, '#folderRow .fangorn-toolbar-icon')
     delete_modal = Locator(By.CSS_SELECTOR, 'span.btn:nth-child(1)')
 
-'''Note that the class FilesPage in pages/project.py is used for test_project_files.py. 
-The class FileWidget in components/project.py is used for tests test_file_widget_loads 
-and test_addon_files_load in test_project.py. 
+
+'''Note that the class FilesPage in pages/project.py is used for test_project_files.py.
+The class FileWidget in components/project.py is used for tests test_file_widget_loads
+and test_addon_files_load in test_project.py.
 In the future, we may want to put all files tests in one place.'''

--- a/pages/user.py
+++ b/pages/user.py
@@ -48,7 +48,7 @@ class ProfileInformationPage(BaseUserSettingsPage):
 class AccountSettingsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/account/'
 
-    identity = Locator(By.CSS_SELECTOR, '#connectedEmails')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Connected emails panel"]')
 
 class ConfigureAddonsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/addons/'
@@ -70,7 +70,7 @@ class DeveloperAppsPage(BaseUserSettingsPage):
 
     url = settings.OSF_HOME + '/settings/applications/'
 
-    identity = Locator(By.CSS_SELECTOR, '#applicationListPage')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Developer apps"')
 
 class EmberPersonalAccessTokenPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/tokens/'
@@ -82,4 +82,4 @@ class PersonalAccessTokenPage(BaseUserSettingsPage):
 
     url = settings.OSF_HOME + '/settings/tokens/'
 
-    identity = Locator(By.CSS_SELECTOR, '#personalTokenListPage')
+    identity = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Personal access"]')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose

The account settings page is in the process of becoming fully 'emberized'. See ticket here: https://openscience.atlassian.net/browse/ENG-199. As these tickets complete development, we will have to update our tests to accommodate for any changes in tests and locators. 

This test covers the updates included in the following sections
* Account settings
* Personal access tokens 
* Developer apps

## Summary of Changes

1 - Outdated locators have been updated to support embosfed pages
2 - Extra spacing has been added to meet flake8 standards

## Testing Changes Moving Forward

As development continues on the Embosfed User Settings, we will need to continually update this test for proper coverage. 

## Ticket

https://openscience.atlassian.net/browse/ENG-756
