### PR TITLE
Remove references to IE

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You'll need the webdriver of your choice and Python3.
 
 ##### Installing a webdriver:
 
-In order for Selenium to be able to control your local browser, you will need to install [drivers](https://seleniumhq.github.io/selenium/docs/api/py/#drivers) for any browsers in which you desire to run these tests. Start with a driver such as [GekoDriver](https://github.com/mozilla/geckodriver/releases) (firefox) or [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) (Note: it is not suggested you run these tests in Safari or IE).
+In order for Selenium to be able to control your local browser, you will need to install [drivers](https://seleniumhq.github.io/selenium/docs/api/py/#drivers) for any browsers in which you desire to run these tests. Start with a driver such as [GekoDriver](https://github.com/mozilla/geckodriver/releases) (firefox) or [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads). (Note: IE is not supported. Safari is only partially supported -- running the tests in Safari is not recommended).
 
 Go to any of the driver links above, install the applicable driver for your system, and move the executable into your *PATH*, e. g., place it in */usr/bin* or */usr/local/bin*.
 

--- a/base/expected_conditions.py
+++ b/base/expected_conditions.py
@@ -23,25 +23,3 @@ class window_at_index(object):
 
     def __call__(self, driver):
         return len(driver.window_handles) > self.page_index
-
-
-class correct_keys_sent(object):
-    """ An Exception used for checking if the correct keys have been sent to an input.
-    This is used for repeatedly attempting to send keys to IE because sometimes it sends the
-    incorrect keys.
-
-    Note: This is not a great example of an expected condition because it changes what's on the page.
-    """
-    def __init__(self, element, keys, existing_keys):
-        self.element = element
-        self.keys = keys
-        self.correct_keys = existing_keys + keys
-
-    def __call__(self, driver):
-
-        if self.element.get_attribute('value') == self.correct_keys:
-            return True
-        else:
-            self.element.clear()
-            self.element.send_keys(self.correct_keys)
-            return False

--- a/settings.py
+++ b/settings.py
@@ -102,7 +102,6 @@ caps = {
         {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'edge': {'browser': 'Edge', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536', 'browser_version': '17.0'},
     'firefox': {'browser': 'Firefox', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
-    'msie': {'browser': 'IE', 'browser_version': '11', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'android': {'device': 'Samsung Galaxy S8', 'realMobile': 'true', 'os_version': '7.0'},
     'ios': {'device': 'iPhone 7', 'realMobile': 'true', 'os_version': '10.0'},
     'safari': {'browser': 'Safari', 'browser_version': '10.1', 'os': 'OS X', 'os_version': 'Sierra',

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -100,15 +100,6 @@ def test_travis_firefox(ctx, numprocesses=None):
     test_module(ctx)
 
 @task
-def test_travis_msie(ctx, numprocesses=None):
-    """
-    Run tests on the latest Microsoft Internet Explorer
-    """
-    flake(ctx)
-    print('Testing modules in "{}" in MSIE'.format('tests'))
-    test_module(ctx)
-
-@task
 def test_travis_android(ctx, numprocesses=None):
     """
     Run tests on Android 7.0, Samsung Galaxy S8


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
We don’t test in IE anymore -- remove all references to IE from the suite.


## Summary of Changes
References to IE were removed.

Here are the files I touched:

`
tasks/__init__.py
103:def test_travis_msie(ctx, numprocesses=None):
105:    Run tests on the latest Microsoft Internet Explorer
108:    print('Testing modules in "{}" in MSIE'.format('tests'))

README.md
18:(Note: it is not suggested you run these tests in Safari or IE).

settings.py
105:    'msie': {'browser': 'IE', 'browser_version': '11', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},

base/expected_conditions.py
30:    This is used for repeatedly attempting to send keys to IE because sometimes it sends the
Gnar:OSF-Integration-Tests ajlisk$ ack -i '(?:[^kr]ie|explorer)\b'
`


## Testing Changes Moving Forward
We explicitly don't support IE -- I updated the README.md to that effect.


## Ticket

https://openscience.atlassian.net/browse/ENG-829
