### PR TITLE
Clean up forks and supplemental materials

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -100,3 +100,4 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
+    supplemental_link = Locator(By.CSS_SELECTOR, 'h6[class="detail-header-info"] > div:last-child > a:last-child')

--- a/pages/project.py
+++ b/pages/project.py
@@ -66,6 +66,9 @@ class ForksPage(GuidBasePage):
     create_fork_modal_button = Locator(By.CSS_SELECTOR, '.modal-footer .btn-info')
     cancel_modal_button = Locator(By.CSS_SELECTOR, '.modal-footer .btn-default')
     info_toast = Locator(By.CSS_SELECTOR, '.toast-info')
+    fork_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Title"]')
+    fork_authors = Locator(By.CSS_SELECTOR, 'div[class="_NodeCard__authors_1i3kzz"]')
+    placeholder_text = Locator(By.CSS_SELECTOR, 'div[class="_Forks__placeholder_1xlord"]')
 
     # Group Locators
     listed_forks = GroupLocator(By.CSS_SELECTOR, '.list-group-item')

--- a/pages/user.py
+++ b/pages/user.py
@@ -16,8 +16,8 @@ class UserProfilePage(GuidBasePage):
 
     #TODO: Reconsider using a component here (and using component locators correctly)
     identity = Locator(By.CLASS_NAME, 'profile-fullname', settings.LONG_TIMEOUT)
-    no_public_projects_text = Locator(By.CSS_SELECTOR, '#publicProjects .help-block', settings.QUICK_TIMEOUT)
-    no_public_components_text = Locator(By.CSS_SELECTOR, '#publicComponents .help-block', settings.QUICK_TIMEOUT)
+    no_public_projects_text = Locator(By.CSS_SELECTOR, '#publicProjects .help-block')
+    no_public_components_text = Locator(By.CSS_SELECTOR, '#publicComponents .help-block')
     edit_profile_link = Locator(By.CSS_SELECTOR, '#edit-profile-settings')
 
     #TODO: Seperate out by component if it becomes necessary

--- a/pages/user.py
+++ b/pages/user.py
@@ -16,8 +16,8 @@ class UserProfilePage(GuidBasePage):
 
     #TODO: Reconsider using a component here (and using component locators correctly)
     identity = Locator(By.CLASS_NAME, 'profile-fullname', settings.LONG_TIMEOUT)
-    no_public_projects_text = Locator(By.CSS_SELECTOR, '#publicProjects .help-block')
-    no_public_components_text = Locator(By.CSS_SELECTOR, '#publicComponents .help-block')
+    no_public_projects_text = Locator(By.CSS_SELECTOR, '#publicProjects .help-block', settings.QUICK_TIMEOUT)
+    no_public_components_text = Locator(By.CSS_SELECTOR, '#publicComponents .help-block', settings.QUICK_TIMEOUT)
     edit_profile_link = Locator(By.CSS_SELECTOR, '#edit-profile-settings')
 
     #TODO: Seperate out by component if it becomes necessary

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -27,7 +27,7 @@ class TestPreprintWorkflow:
 
     @markers.dont_run_on_prod
     @markers.core_functionality
-    def test_create_preprint_from_landing(self, driver, landing_page, project_with_file):
+    def test_create_preprint_from_landing(self, session, driver, landing_page, project_with_file):
 
         landing_page.add_preprint_button.click()
         submit_page = PreprintSubmitPage(driver, verify=True)
@@ -74,6 +74,10 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
 
         assert preprint_detail.title.text == project_with_file.title
+
+        # Delete supplemental project created during workflow
+        supplemental_guid = preprint_detail.supplemental_link.text[12:17]
+        osf_api.delete_project(session, supplemental_guid, None)
 
     @markers.smoke_test
     @markers.core_functionality

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,7 +1,7 @@
 import pytest
-
 import markers
 import settings
+
 from api import osf_api
 from pages.project import ProjectPage, RequestAccessPage, AnalyticsPage, ForksPage
 from pages.login import LoginPage, login, logout
@@ -105,14 +105,21 @@ class TestForksPage:
 
     @markers.dont_run_on_prod
     @markers.core_functionality
-    def test_create_fork(self, must_be_logged_in, forks_page):
+    def test_create_fork(self, driver, session, must_be_logged_in, forks_page):
+        forks_page.placeholder_text.present()
         assert len(forks_page.listed_forks) == 0
         forks_page.new_fork_button.click()
         forks_page.create_fork_modal_button.click()
         forks_page.info_toast.present()
         forks_page.reload()
         forks_page.verify()
+        forks_page.fork_authors.present()
         assert len(forks_page.listed_forks) == 1
+
+        # Clean-up leftover fork
+        href = forks_page.fork_link.get_attribute('href')
+        fork_guid = href[20:]
+        osf_api.delete_project(session, fork_guid, None)
 
 
 class TestAnalyticsPage:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -26,7 +26,7 @@ class ProfilePageMixin:
     def test_nothings_public(self, profile_page):
         """Confirm there the user has no public projects.
         """
-        assert profile_page.no_public_projects_text.present()
+        # assert profile_page.no_public_projects_text.present()
         assert profile_page.no_public_components_text.present()
 
         if settings.PRODUCTION:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -26,7 +26,7 @@ class ProfilePageMixin:
     def test_nothings_public(self, profile_page):
         """Confirm there the user has no public projects.
         """
-        # assert profile_page.no_public_projects_text.present()
+        assert profile_page.no_public_projects_text.present()
         assert profile_page.no_public_components_text.present()
 
         if settings.PRODUCTION:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose

Originally we expected to update locators in test_user.py. After further troubleshooting, we found that the failures from _test_nothings_public_ were the result of leftover projects from Forks & Supplemental materials. So the tests were updated to perform a cleanup after each run. 

Sidenote: To help with troubleshooting in the future, each new project created via API now contains 2 tags:
1 - qatest
2 - name_of_the_test

## Summary of Changes 

1 - Delete the supplemental project created during _test_preprints.py::TestPreprintWorkflow_
2 - Delete the fork created during _test_project.py::test_create_fork_
3 - Added tags to newly created projects that specify the current test


## Ticket

https://openscience.atlassian.net/browse/ENG-1128
https://openscience.atlassian.net/browse/ENG-863