### PR TITLE
Edge fix

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_landing.py']
+    args = ['-s', '-v', 'tests/test_login.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_preprints.py']
+    args = ['-s', '-v', 'tests/test_project.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_my_projects.py']
+    args = ['-s', '-v', 'tests/test_navbar.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_quickfiles.py']
+    args = ['-s', '-v', 'tests/test_register.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_registries.py']
+    args = ['-s', '-v', 'tests/test_search.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_login.py']
+    args = ['-s', '-v', 'tests/test_meetings.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_project.py']
+    args = ['-s', '-v', 'tests/test_project_files.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -43,7 +43,7 @@ def requirements(ctx, dev=False):
     ctx.run(cmd, echo=True)
 
 @task
-def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
+def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '0']):
     """Helper for running tests.
     """
     import pytest
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_user.py']
+    args = ['-s', '-v']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'test_dashboard.py']
+    args = ['-s', '-v', 'tests/test_dashboard.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '0']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v']
+    args = ['-s', '-v', 'tests/test_meetings.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_dashboard.py']
+    args = ['-s', '-v', 'tests/test_institutions.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v']
+    args = ['-s', '-v', 'test_dashboard.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_search.py']
+    args = ['-s', '-v', 'tests/test_user.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_institutions.py']
+    args = ['-s', '-v', 'tests/test_landing.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_navbar.py']
+    args = ['-s', '-v', 'tests/test_preprints.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '0']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_meetings.py']
+    args = ['-s', '-v']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_project_files.py']
+    args = ['-s', '-v', 'tests/test_quickfiles.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_meetings.py']
+    args = ['-s', '-v', 'tests/test_my_projects.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -52,7 +52,7 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '3']):
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
-    args = ['-s', '-v', 'tests/test_register.py']
+    args = ['-s', '-v', 'tests/test_registries.py']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
 

--- a/tests/test_meetings.py
+++ b/tests/test_meetings.py
@@ -57,7 +57,7 @@ class TestMeetingsPage:
         meeting_name = meetings_page.top_meeting_link.text
         meetings_page.top_meeting_link.click()
         meeting_detail = MeetingDetailPage(driver, verify=True)
-        assert meeting_name == meeting_detail.meeting_title.text.strip()
+        assert meeting_name.strip() == meeting_detail.meeting_title.text.strip()
 
 
 class TestMeetingDetailPage:
@@ -77,7 +77,7 @@ class TestMeetingDetailPage:
         entry_title = meeting_detail_page.first_entry_link.text
         meeting_detail_page.first_entry_link.click()
         project_page = ProjectPage(driver, verify=True)
-        assert entry_title == project_page.title.text
+        assert entry_title.strip() == project_page.title.text
 
 # Future tests could include:
 # - click download button, confirm download count increases (this will have to be omitted in production test runs)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Fix all issues with Microsoft Edge during our selenium test runs. After running all test locally and through Travis, we have learned that the only test failing is test_meetings.py. More specifically, the test_meeting_detail test is having a problem comparing text and will be fixed. 

> Assert failure: "TEST MEETING " !=  "TEST MEETING"

The fix: Use String's strip() class to remove the extra whitespaces.


## Summary of Changes
- Remove reruns from selenium suite
- Fix test_meetings.py



## Testing Changes Moving Forward
Reruns are currently problematic and are being investigated in this ticket: https://openscience.atlassian.net/browse/ENG-1226


## Ticket

https://openscience.atlassian.net/browse/ENG-1199
