### PR TITLE
Split Travis builds into two stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,23 @@ jobs:
     - DOMAIN='prod'
     - PREFERRED_NODE='ucrdq'
     script: invoke test_travis_on_prod
-  - if: branch != master
-    env: TEST_BUILD="chrome"
-  - if: branch != master
-    env: TEST_BUILD="firefox"
-  - if: branch != master
-    env: TEST_BUILD="edge"
-script:
-- invoke test_travis_$TEST_BUILD
+  - stage: Staging tests part one
+    if: branch != master
+    env: TEST_BUILD='chrome'
+    script: invoke test_travis_part_one
+  -  # stage part one
+    env: TEST_BUILD='firefox'
+    script: invoke test_travis_part_one
+  -  # stage part one
+    env: TEST_BUILD='edge'
+    script: invoke test_travis_part_one
+  - stage: Staging tests part two
+    if: branch != master
+    env: TEST_BUILD='chrome'
+    script: invoke test_travis_part_two
+  -  # stage part two
+    env: TEST_BUILD='firefox'
+    script: invoke test_travis_part_two
+  -  # stage part two
+    env: TEST_BUILD='edge'
+    script: invoke test_travis_part_two

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 invoke==0.15.0
 selenium==3.6.0
-pytest==3.2.3
+pytest==3.5.0
 flake8==2.4.0
 flake8-quotes==0.3.0
 autopep8==1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pytest==3.5.0
 flake8==2.4.0
 flake8-quotes==0.3.0
 autopep8==1.3.3
-pytest-xdist==1.15.0
 requests>=2.20.0
 pythosf==0.0.9
 environs==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,5 @@ requests>=2.20.0
 pythosf==0.0.9
 environs==3.0.0
 faker==0.9.0
-pytest-rerunfailures==4.1
 pre-commit==1.18.3
 ipdb==0.12.2

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -81,8 +81,7 @@ def test_travis_on_prod(ctx):
 @task
 def test_travis_part_one(ctx):
     """Run first group of tests on the browser defined by TEST_BUILD."""
-    all_test_files = glob.glob('tests/test_*.py')
-    all_test_files.sort()
+    all_test_files = _get_test_file_list()
     midpoint = len(all_test_files) // 2
     file_list = all_test_files[:midpoint]
     test_travis_with_retries(ctx, 'part one', file_list)
@@ -90,11 +89,15 @@ def test_travis_part_one(ctx):
 @task
 def test_travis_part_two(ctx):
     """Run second group of tests on the browser defined by TEST_BUILD."""
-    all_test_files = glob.glob('tests/test_*.py')
-    all_test_files.sort()
+    all_test_files = _get_test_file_list()
     midpoint = len(all_test_files) // 2
     file_list = all_test_files[midpoint:]
     test_travis_with_retries(ctx, 'part two', file_list)
+
+def _get_test_file_list():
+    all_test_files = glob.glob('tests/test_*.py')
+    all_test_files.sort()
+    return all_test_files
 
 @task
 def test_travis_with_retries(ctx, partition_name, file_list):

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,6 +7,7 @@ commands, run ``$ invoke --list``.
 
 import os
 import sys
+import glob
 import logging
 from invoke import task
 
@@ -80,53 +81,40 @@ def test_travis_on_prod(ctx):
 @task
 def test_travis_part_one(ctx):
     """Run first group of tests on the browser defined by TEST_BUILD."""
-    flake(ctx)
-
-    part_one_files = ['test_dashboard.py', 'test_institutions.py', 'test_landing.py',
-                      'test_login.py', 'test_meetings.py', 'test_my_projects.py',
-                      'test_navbar.py']
-    part_one_file_names = ['tests/{}'.format(x) for x in part_one_files]
-
-    print('Testing part one modules in "/test/" in {}'.format(os.environ['TEST_BUILD']))
-    retcode = test_module_wo_exit(ctx, params=part_one_file_names)
-
-    # retcodes: http://doc.pytest.org/en/latest/usage.html#possible-exit-codes
-    if retcode != 1:
-        sys.exit(retcode)
-
-    part_one_file_names = ['--last-failed', '--last-failed-no-failures', 'none'] + part_one_file_names
-
-    for i in range(1, MAX_TRAVIS_RETRIES+1):
-        print('Retesting part one failures, iteration {}, in "/test/" '
-              'in {}'.format(i, os.environ['TEST_BUILD']))
-        retcode = test_module_wo_exit(ctx, params=part_one_file_names)
-        if retcode != 1:
-            break
-
-    sys.exit(retcode)
+    all_test_files = glob.glob('tests/test_*.py')
+    all_test_files.sort()
+    midpoint = len(all_test_files) // 2
+    file_list = all_test_files[:midpoint]
+    test_travis_with_retries(ctx, 'part one', file_list)
 
 @task
 def test_travis_part_two(ctx):
     """Run second group of tests on the browser defined by TEST_BUILD."""
+    all_test_files = glob.glob('tests/test_*.py')
+    all_test_files.sort()
+    midpoint = len(all_test_files) // 2
+    file_list = all_test_files[midpoint:]
+    test_travis_with_retries(ctx, 'part two', file_list)
+
+@task
+def test_travis_with_retries(ctx, partition_name, file_list):
+    """Run group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 
-    part_two_files = ['test_preprints.py', 'test_project.py', 'test_project_files.py',
-                      'test_quickfiles.py', 'test_register.py', 'test_registries.py',
-                      'test_search.py', 'test_user.py']
-    part_two_file_names = ['tests/{}'.format(x) for x in part_two_files]
-
-    print('Testing part one modules in "/test/" in {}'.format(os.environ['TEST_BUILD']))
-    retcode = test_module_wo_exit(ctx, params=part_two_file_names)
+    print('Testing {} modules in "/tests/" in {}'.format(partition_name, os.environ['TEST_BUILD']))
+    print('File list for {} is: {}'.format(partition_name, file_list))
+    retcode = test_module_wo_exit(ctx, params=file_list)
 
     if retcode != 1:
         sys.exit(retcode)
 
-    part_two_file_names = ['--last-failed', '--last-failed-no-failures', 'none'] + part_two_file_names
+    file_list = ['--last-failed', '--last-failed-no-failures', 'none'] + file_list
 
     for i in range(1, MAX_TRAVIS_RETRIES+1):
-        print('Retesting part two failures, iteration {}, in "/test/" '
-              'in {}'.format(i, os.environ['TEST_BUILD']))
-        retcode = test_module_wo_exit(ctx, params=part_two_file_names)
+        print('Retesting {} failures, iteration {}, in "/test/" '
+              'in {}'.format(partition_name, i, os.environ['TEST_BUILD']))
+        retcode = test_module_wo_exit(ctx, params=file_list)
+
         if retcode != 1:
             break
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -15,7 +15,6 @@ logging.getLogger('invoke').setLevel(logging.CRITICAL)
 
 HERE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 BIN_PATH = os.path.dirname(sys.executable)
-
 bin_prefix = lambda cmd: os.path.join(BIN_PATH, cmd)
 MAX_TRAVIS_RETRIES = int(os.getenv('MAX_TRAVIS_RETRIES', 3))
 
@@ -45,23 +44,15 @@ def requirements(ctx, dev=False):
     ctx.run(cmd, echo=True)
 
 @task
-def test_module_wo_exit(ctx, module=None, numprocesses=1, params=None):
+def test_module_wo_exit(ctx, module=None, params=None):
     """Helper for running tests.
     """
     import pytest
-    if not numprocesses:
-        from multiprocessing import cpu_count
-        numprocesses = cpu_count()
-    # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
-    # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
 
     if params is None:
         params = []
 
     args = ['-s', '-v', '--tb=short']
-    if numprocesses > 1:
-        args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
-
     for e in [module, params]:
         if e:
             args.extend([e] if isinstance(e, str) else e)
@@ -71,14 +62,14 @@ def test_module_wo_exit(ctx, module=None, numprocesses=1, params=None):
     return retcode
 
 @task
-def test_module(ctx, module=None, numprocesses=1, params=None):
+def test_module(ctx, module=None, params=None):
     """Helper for running tests.
     """
-    retcode = test_module_wo_exit(ctx, module, numprocesses, params)
+    retcode = test_module_wo_exit(ctx, module, params)
     sys.exit(retcode)
 
 @task
-def test_travis_on_prod(ctx, numprocesses=None):
+def test_travis_on_prod(ctx):
     """
     Runs targeted prod smoke tests on the latest Chrome
     """
@@ -87,7 +78,7 @@ def test_travis_on_prod(ctx, numprocesses=None):
     test_module(ctx, module=['-m','smoke_test'])
 
 @task
-def test_travis_part_one(ctx, numprocesses=None):
+def test_travis_part_one(ctx):
     """Run first group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 
@@ -115,7 +106,7 @@ def test_travis_part_one(ctx, numprocesses=None):
     sys.exit(retcode)
 
 @task
-def test_travis_part_two(ctx, numprocesses=None):
+def test_travis_part_two(ctx):
     """Run second group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -74,60 +74,6 @@ def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '1']):
     sys.exit(retcode)
 
 @task
-def test_travis_safari(ctx, numprocesses=None):
-    """
-    Run tests on the latest Safari
-    """
-    flake(ctx)
-    print('Testing modules in "{}" in Safari'.format('tests'))
-    test_module(ctx)
-
-@task
-def test_travis_chrome(ctx, numprocesses=None):
-    """
-    Run tests on the latest Chrome
-    """
-    flake(ctx)
-    print('Testing modules in "{}" in Chrome'.format('tests'))
-    test_module(ctx)
-
-@task
-def test_travis_edge(ctx, numprocesses=None):
-    """
-    Run tests on the latest Edge
-    """
-    flake(ctx)
-    print('Testing modules in "{}" in Edge'.format('tests'))
-    test_module(ctx)
-
-@task
-def test_travis_firefox(ctx, numprocesses=None):
-    """
-    Run tests on the latest Firefox
-    """
-    flake(ctx)
-    print('Testing modules in "{}" in Firefox'.format('tests'))
-    test_module(ctx)
-
-@task
-def test_travis_android(ctx, numprocesses=None):
-    """
-    Run tests on Android 7.0, Samsung Galaxy S8
-    """
-    flake(ctx)
-    print('Testing modules in "{}" in android'.format('tests'))
-    test_module(ctx)
-
-@task
-def test_travis_ios(ctx, numprocesses=None):
-    """
-    Run tests on ios 10.0, iPhone 7
-    """
-    flake(ctx)
-    print('Testing modules in "{}" on ios'.format('tests'))
-    test_module(ctx)
-
-@task
 def test_travis_on_prod(ctx, numprocesses=None):
     """
     Runs targeted prod smoke tests on the latest Chrome
@@ -135,30 +81,6 @@ def test_travis_on_prod(ctx, numprocesses=None):
     flake(ctx)
     print('Testing modules in "{}" in Chrome'.format('tests'))
     test_module(ctx, module=['-m','smoke_test'])
-
-@task
-def test_travis_failures_only_chrome(ctx, numprocesses=None):
-    """
-    Run tests on the latest Chrome
-    """
-    print('Testing modules in "{}" in Chrome'.format('tests'))
-    test_module(ctx, params=['--last-failed', '--last-failed-no-failures', 'none'])
-
-@task
-def test_travis_failures_only_edge(ctx, numprocesses=None):
-    """
-    Run tests on the latest Edge
-    """
-    print('Testing modules in "{}" in Edge'.format('tests'))
-    test_module(ctx, params=['--last-failed', '--last-failed-no-failures', 'none'])
-
-@task
-def test_travis_failures_only_firefox(ctx, numprocesses=None):
-    """
-    Run tests on the latest Firefox
-    """
-    print('Testing modules in "{}" in Firefox'.format('tests'))
-    test_module(ctx, params=['--last-failed', '--last-failed-no-failures', 'none'])
 
 @task
 def test_travis_part_one(ctx, numprocesses=None):

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -45,7 +45,7 @@ def requirements(ctx, dev=False):
     ctx.run(cmd, echo=True)
 
 @task
-def test_module_wo_exit(ctx, module=None, numprocesses=1, params=['--reruns', '1']):
+def test_module_wo_exit(ctx, module=None, numprocesses=1, params=None):
     """Helper for running tests.
     """
     import pytest
@@ -54,6 +54,10 @@ def test_module_wo_exit(ctx, module=None, numprocesses=1, params=['--reruns', '1
         numprocesses = cpu_count()
     # NOTE: Subprocess to compensate for lack of thread safety in the httpretty module.
     # https://github.com/gabrielfalcao/HTTPretty/issues/209#issue-54090252
+
+    if params is None:
+        params = []
+
     args = ['-s', '-v', '--tb=short']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
@@ -67,7 +71,7 @@ def test_module_wo_exit(ctx, module=None, numprocesses=1, params=['--reruns', '1
     return retcode
 
 @task
-def test_module(ctx, module=None, numprocesses=1, params=['--reruns', '1']):
+def test_module(ctx, module=None, numprocesses=1, params=None):
     """Helper for running tests.
     """
     retcode = test_module_wo_exit(ctx, module, numprocesses, params)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -75,7 +75,7 @@ def test_travis_on_prod(ctx):
     Runs targeted prod smoke tests on the latest Chrome
     """
     flake(ctx)
-    print('Testing modules in "{}" in Chrome'.format('tests'))
+    print('>>> Testing modules in "{}" in Chrome'.format('tests'))
     test_module(ctx, module=['-m','smoke_test'])
 
 @task
@@ -104,8 +104,8 @@ def test_travis_with_retries(ctx, partition_name, file_list):
     """Run group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 
-    print('Testing {} modules in "/tests/" in {}'.format(partition_name, os.environ['TEST_BUILD']))
-    print('File list for {} is: {}'.format(partition_name, file_list))
+    print('>>> Testing {} modules in "/tests/" in {}'.format(partition_name, os.environ['TEST_BUILD']))
+    print('>>> File list for {} is: {}'.format(partition_name, file_list))
     retcode = test_module_wo_exit(ctx, params=file_list)
 
     if retcode != 1:
@@ -114,7 +114,7 @@ def test_travis_with_retries(ctx, partition_name, file_list):
     file_list = ['--last-failed', '--last-failed-no-failures', 'none'] + file_list
 
     for i in range(1, MAX_TRAVIS_RETRIES+1):
-        print('Retesting {} failures, iteration {}, in "/test/" '
+        print('>>> Retesting {} failures, iteration {}, in "/test/" '
               'in {}'.format(partition_name, i, os.environ['TEST_BUILD']))
         retcode = test_module_wo_exit(ctx, params=file_list)
 


### PR DESCRIPTION
## Purpose

Split selenium tests into two stages to avoid hitting Travis's time limits.

## Summary of Changes

### Functional changes

Split non-prod travis testing into two stages.  Each stage gets an hour to run. Test files are split into two approixmately-equal sized groups and assigned to each stage.  Each stage tests the three browsers simultaneously.

### Cleanups

* Remove unused and redundant tasks
* Remove unused and inappropriate pytest-xdist module and related code.
* Remove troublesome -rerunfailures module, shifting that responsibility to multiple pytest runs.

## Testing Changes Moving Forward

Stage two won't run unless stage one passes.  Parameterized testing will come in a later PR.  Can run targeted tests by modifying the `glob.glob` line in `tasks/__init__.py`.

## Ticket

Stolen from Charlie Bucket.
