### PR TITLE
Remove Mind & Life custom domain

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -50,8 +50,7 @@ domains = {
             'https://osf.ucla.edu',
             'https://osf.ucr.edu',
             'https://osf.wustl.edu',
-            'https://osf.research.vcu.edu',
-            'https://research.mindandlife.org'
+            'https://osf.research.vcu.edu'
         ]
     }
 }


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose

Mind and Life have decided to remove the custom domain https://research.mindandlife.org/ from their DNS.

## Summary of Changes

* Remove the expired custom domain.

## Testing Changes Moving Forward

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-
