### PR TITLE
Feature/custom collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ nosetests.xml
 .idea
 .hg
 .hgignore
+.pytest_cache
 env/
 mathenv
 cover/

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -133,6 +133,21 @@ def delete_project(session, guid, user=None):
             n.get()
             n.delete()
 
+
+def get_custom_collections(session, user=None):
+    if not user:
+        user = current_user(session)
+
+    collections_url = 'https://api.test.osf.io/v2/collections/'
+    data = session.get(collections_url)
+
+    collections = []
+    for collection in data['data']:
+        collections.append(collection['attributes']['title'])
+
+    print('\n{}'.format(collections))
+
+
 # TODO rename this to get_node_providers, and create new function that actually IS get_node_addons -
 #  note, this is confusing, talk to BrianG before we change this
 def get_node_addons(session, node_id):

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -135,6 +135,16 @@ def delete_project(session, guid, user=None):
             n.delete()
 
 
+def create_custom_collection(session):
+    collections_url = '{}/v2/collections/'.format(session.api_base_url)
+
+    payload = {
+        'title': 'Selenium API Custom Collection',
+    }
+
+    session.post(collections_url, item_type='collections', attributes=payload)
+
+
 def delete_custom_collections(session):
     collections_url = '{}/v2/collections/'.format(session.api_base_url)
     data = session.get(collections_url)

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -7,6 +7,7 @@ import requests
 from pythosf import client
 logger = logging.getLogger(__name__)
 
+
 def get_default_session():
     return client.Session(api_base_url=settings.API_DOMAIN, auth=(settings.USER_ONE, settings.USER_ONE_PASSWORD))
 
@@ -134,18 +135,20 @@ def delete_project(session, guid, user=None):
             n.delete()
 
 
-def get_custom_collections(session, user=None):
+def delete_custom_collections(session, user=None):
     if not user:
         user = current_user(session)
 
+    # TODO: create this url using client.py
+    collection_self_url = ''
     collections_url = 'https://api.test.osf.io/v2/collections/'
+
     data = session.get(collections_url)
 
-    collections = []
     for collection in data['data']:
-        collections.append(collection['attributes']['title'])
-
-    print('\n{}'.format(collections))
+        if not collection['attributes']['bookmarks']:
+            collection_self_url = collections_url + collection['id']
+            requests.delete(collection_self_url, auth=session.auth)
 
 
 # TODO rename this to get_node_providers, and create new function that actually IS get_node_addons -

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -136,6 +136,8 @@ def delete_project(session, guid, user=None):
 
 
 def create_custom_collection(session):
+    """Create a new custom collection. You can modify the title of the collection here as well.
+    """
     collections_url = '{}/v2/collections/'.format(session.api_base_url)
 
     payload = {
@@ -146,13 +148,15 @@ def create_custom_collection(session):
 
 
 def delete_custom_collections(session):
+    """Delete all custom collections for the current user.
+    """
     collections_url = '{}/v2/collections/'.format(session.api_base_url)
     data = session.get(collections_url)
 
     for collection in data['data']:
         if not collection['attributes']['bookmarks']:
             collection_self_url = collections_url + collection['id']
-            requests.delete(collection_self_url, auth=session.auth)
+            session.delete(url=collection_self_url, item_type=None)
 
 
 # TODO rename this to get_node_providers, and create new function that actually IS get_node_addons -

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -135,14 +135,8 @@ def delete_project(session, guid, user=None):
             n.delete()
 
 
-def delete_custom_collections(session, user=None):
-    if not user:
-        user = current_user(session)
-
-    # TODO: create this url using client.py
-    collection_self_url = ''
-    collections_url = 'https://api.test.osf.io/v2/collections/'
-
+def delete_custom_collections(session):
+    collections_url = '{}/v2/collections/'.format(session.api_base_url)
     data = session.get(collections_url)
 
     for collection in data['data']:

--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -93,5 +93,5 @@ class TestMyProjectsPage:
         assert not my_projects_page.first_custom_collection.present()
 
     def test_bulk_delete(self, driver, session):
-        osf_api.delete_custom_collections(session, None)
+        osf_api.delete_custom_collections(session)
         assert True

--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -93,5 +93,5 @@ class TestMyProjectsPage:
         assert not my_projects_page.first_custom_collection.present()
 
     def test_bulk_delete(self, driver, session):
-        osf_api.get_custom_collections(session, None)
+        osf_api.delete_custom_collections(session, None)
         assert True

--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -42,8 +42,10 @@ class TestMyProjectsPage:
         assert project_page.title.text == title, 'Project title incorrect.'
         osf_api.delete_project(session, guid, None)
 
-    def test_custom_collection(self, driver, session, default_project, my_projects_page, fake):
+    def test_create_custom_collection(self, driver, session, default_project, my_projects_page, fake):
         current_browser = driver.desired_capabilities.get('browserName')
+
+        osf_api.delete_custom_collections(session)
 
         # Create new custom collection
         name = fake.sentence(nb_words=2, variable_nb_words=False)
@@ -83,6 +85,16 @@ class TestMyProjectsPage:
         WebDriverWait(driver, 5).until(EC.text_to_be_present_in_element((By.CSS_SELECTOR, 'li[data-index="4"] span'), '(1)'))
         assert '1' in my_projects_page.first_custom_collection.text
 
+        osf_api.delete_custom_collections(session)
+
+    def test_delete_custom_collection(self, session, driver, my_projects_page):
+        # API Setup
+        osf_api.delete_custom_collections(session)
+        osf_api.create_custom_collection(session)
+
+        my_projects_page.goto()
+        assert my_projects_page.first_custom_collection.text
+
         # Delete the custom collection
         my_projects_page.first_collection_settings_button.click()
         my_projects_page.first_collection_remove_button.click()
@@ -91,7 +103,3 @@ class TestMyProjectsPage:
         # Wait for danger modal to close
         WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, '#removeColl .btn-danger')))
         assert not my_projects_page.first_custom_collection.present()
-
-    def test_bulk_delete(self, driver, session):
-        osf_api.delete_custom_collections(session)
-        assert True

--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -19,7 +19,8 @@ def my_projects_page(driver):
 
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestMyProjectsPage:
-
+    """ Custom collections must implement a PRE-delete setup to start in a clean state.
+    """
     @markers.dont_run_on_prod
     @markers.core_functionality
     def test_create_new_project(self, driver, session, my_projects_page, fake):
@@ -84,8 +85,6 @@ class TestMyProjectsPage:
         # Wait for new collection to have '(1)' in the name
         WebDriverWait(driver, 5).until(EC.text_to_be_present_in_element((By.CSS_SELECTOR, 'li[data-index="4"] span'), '(1)'))
         assert '1' in my_projects_page.first_custom_collection.text
-
-        osf_api.delete_custom_collections(session)
 
     def test_delete_custom_collection(self, session, driver, my_projects_page):
         # API Setup

--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -91,3 +91,7 @@ class TestMyProjectsPage:
         # Wait for danger modal to close
         WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, '#removeColl .btn-danger')))
         assert not my_projects_page.first_custom_collection.present()
+
+    def test_bulk_delete(self, driver, session):
+        osf_api.get_custom_collections(session, None)
+        assert True


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
We need to delete the leftover custom collections from failing tests. 1 failed test will cause failures until they are manually deleted on the front end. In this update, we added a pre-delete to all of the user's custom collections using an API call at the beginning of each test. This delete will also be used to during the cleanup step. An API call to create custom collections was also created for efficiency and refactoring. 


## Summary of Changes
1 - Bulk delete custom collections
2 - Create custom collection via API
3 - Refactor tests


## Testing Changes Moving Forward
We can improve the create custom collection API method by allowing the caller to pass in the string of a name they choose. 

We can also improve on the test by automating the custom collection rename feature. This ticket can be found here: https://openscience.atlassian.net/browse/ENG-1508


## Ticket
https://openscience.atlassian.net/browse/ENG-1123
