### PR TITLE
Feature/marxiv

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -228,6 +228,17 @@ def get_providers_list(session=None, type='preprints'):
     return session.get(url)['data']
 
 
+def get_provider_status(provider):
+    """Return the boolean attribute `allow_submissions` from the dictionary object (provider)
+    """
+    allow_submissions = provider['attributes']['allow_submissions']
+    if allow_submissions:
+        return True
+    else:
+        print('(Allow submissions: {}) '.format(allow_submissions), end='')
+        return False
+
+
 def connect_provider_root_to_node(
     session, provider, external_account_id,
     node_id=settings.PREFERRED_NODE,

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -235,7 +235,6 @@ def get_provider_status(provider):
     if allow_submissions:
         return True
     else:
-        print('(Allow submissions: {}) '.format(allow_submissions), end='')
         return False
 
 

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -49,7 +49,8 @@ class PreprintLandingPage(BasePreprintPage):
     identity = Locator(By.CSS_SELECTOR, '.ember-application .preprint-header', settings.LONG_TIMEOUT)
     add_preprint_button = Locator(By.CLASS_NAME, 'preprint-submit-button', settings.LONG_TIMEOUT)
     search_button = Locator(By.CSS_SELECTOR, '.preprint-search .btn-default')
-
+    submit_navbar = Locator(By.CSS_SELECTOR, '.branded-nav > :nth-child(2)')
+    submit_button = Locator(By.CSS_SELECTOR, '.btn.btn-success')
 
 class PreprintSubmitPage(BasePreprintPage):
     url_addition = 'submit'

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -23,7 +23,7 @@ def landing_page(driver):
     landing_page.goto()
     return landing_page
 
-#TODO: Add checking for missing translations
+# TODO: Add checking for missing translations
 @pytest.mark.usefixtures('must_be_logged_in')
 @pytest.mark.usefixtures('delete_user_projects_at_setup')
 class TestPreprintWorkflow:
@@ -123,6 +123,11 @@ class TestBrandedProviders:
         allow_submissions = osf_api.get_provider_status(provider)
         if allow_submissions:
             PreprintSubmitPage(driver, provider=provider).goto()
+        else:
+            landing_page = PreprintLandingPage(driver, provider=provider)
+            landing_page.goto()
+            assert 'submit' not in landing_page.submit_navbar.text
+            assert not landing_page.submit_button.present()
 
     @markers.smoke_test
     @markers.core_functionality

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -97,6 +97,7 @@ def providers():
     """
     return osf_api.get_providers_list()
 
+
 @pytest.fixture(scope='session')
 def custom_providers():
     """Return the API data of all preprint providers with custom domains.
@@ -119,7 +120,9 @@ class TestBrandedProviders:
 
     @pytest.mark.usefixtures('must_be_logged_in')
     def test_submit_page_loads(self, driver, provider):
-        PreprintSubmitPage(driver, provider=provider).goto()
+        allow_submissions = osf_api.get_provider_status(provider)
+        if allow_submissions:
+            PreprintSubmitPage(driver, provider=provider).goto()
 
     @markers.smoke_test
     @markers.core_functionality


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Marxiv has pages on the OSF that are still accessible to the public, but they will be unsubscribing from our preprint services. In the meantime, they are not able to submit preprints which causes failures in our automated end to end tests. In this fix, we will check each preprint service if they are currently allowing submissions before attempting to submit a preprint. 

## Summary of Changes

1. Allow_submissions - Perform an API check to see which providers allow submissions at the time
2. Confirm status - If a preprint service does not allow submissions, verify the buttons are no longer available on the front end. 

## Reviewer's Actions
Fetch a new local branch
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/84/head:feature/marxiv`

Run this test using:
`pytest tests/test_preprints.py::TestBrandedProviders -s -v`

## Testing Changes Moving Forward
In the future, we may want to expand the check for the url https://test.osf.io/preprints/<preprint>/submit. First, we have to confirm if the 404 page is appropriate/expected for providers not allowing submissions. 

Next, we may want to look into refactoring the osf_api.py method get_provider_status(). It essentially returns a bool which can be done directly in test_preprints.py where it is called. The main reason I left it in is for readability. Without it, tester's moving forward may have a difficult time troubleshooting. 


## Ticket

https://openscience.atlassian.net/browse/ENG-1409
