### PR TITLE
Update Navbars tests locators

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -7,10 +7,10 @@ from selenium.webdriver.common.by import By
 
 class Navbar(BaseElement):
     service_dropdown = Locator(By.CSS_SELECTOR, '.fa-caret-down')
-    home_link = Locator(By.CSS_SELECTOR, '#navbarScope > div > div.navbar-header > div.dropdown.primary-nav.open > ul > li:nth-child(1) > a')
-    preprints_link = Locator(By.CSS_SELECTOR, '#navbarScope > div.container > div.navbar-header > div.dropdown > ul > li:nth-child(2) > a')
-    registries_link = Locator(By.CSS_SELECTOR, '#navbarScope > div.container > div.navbar-header > div.dropdown > ul > li:nth-child(3) > a')
-    meetings_link = Locator(By.CSS_SELECTOR, '#navbarScope > div.container > div.navbar-header > div.dropdown > ul > li:nth-child(4) > a')
+    home_link = Locator(By.CSS_SELECTOR, '.service-dropdown [data-analytics-name="HOME"]')
+    preprints_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="PREPRINTS"]')
+    registries_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="REGISTRIES"]')
+    meetings_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="MEETINGS"]')
     search_link = Locator(By.XPATH, '//a[text()="Search"]')
     support_link = Locator(By.XPATH, '//a[text()="Support"]')
     donate_link = Locator(By.ID, 'navbar-donate')

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -94,6 +94,7 @@ def test_travis_part_two(ctx):
     file_list = all_test_files[midpoint:]
     test_travis_with_retries(ctx, 'part two', file_list)
 
+
 def _get_test_file_list():
     all_test_files = glob.glob('tests/test_*.py')
     all_test_files.sort()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Fixed outdated locators in navbars test to use the new `data-test` css selectors. These outdated locators were causing our Master branch to fail. 


## Summary of Changes
Update locators in logged out homepage navbar
- Home
- Preprints
- Registries
- Meetings

## Reviewer's Actions
Fetch a new local branch
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/87/head:fix/navbar-test`

Run this test using:
`pytest tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
We may need to look into using more `data-test` selectors in our navbars test where applicable. 


## Ticket

https://openscience.atlassian.net/browse/ENG-1510
