### PR TITLE
Feature/project files

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -211,17 +211,19 @@ def upload_fake_file(session, node=None, name='osf selenium test file for testin
     return name, metadata
 
 
-def delete_addon_files(session, provider, guid):
+def delete_addon_files(session, provider, current_browser, guid):
     """Delete all files for the given addon.
     """
     files_url = '{}/v2/nodes/{}/files/{}/'.format(session.api_base_url, guid, provider)
 
-    data = session.get(url=files_url)
+    data = session.get(url=files_url, query_parameters={'page[size]': 20})
 
     for file in data['data']:
         if file['attributes']['kind'] == 'file':
             delete_url = file['links']['delete']
-            delete_file(session, delete_url)
+            file_name = file['attributes']['name']
+            if current_browser in file_name:
+                delete_file(session, delete_url)
 
 
 def delete_file(session, delete_url):

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -211,6 +211,19 @@ def upload_fake_file(session, node=None, name='osf selenium test file for testin
     return name, metadata
 
 
+def delete_addon_files(session, provider, guid):
+    """Delete all files for the given addon.
+    """
+    files_url = '{}/v2/nodes/{}/files/{}/'.format(session.api_base_url, guid, provider)
+
+    data = session.get(url=files_url)
+
+    for file in data['data']:
+        if file['attributes']['kind'] == 'file':
+            delete_url = file['links']['delete']
+            delete_file(session, delete_url)
+
+
 def delete_file(session, delete_url):
     """Delete a file.  A truly stupid method, caller must provide the delete url from the file
     metadata."""

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -24,13 +24,16 @@ MAX_TRAVIS_RETRIES = int(os.getenv('MAX_TRAVIS_RETRIES', 3))
 def flake(ctx):
     ctx.run('flake8 .', echo=True)
 
+
 @task(aliases=['autopep8'])
 def autopep(ctx):
     ctx.run('autopep8 .', echo=True)
 
+
 @task
 def clean(ctx, verbose=False):
     ctx.run('find . -name "*.pyc" -delete', echo=True)
+
 
 @task(aliases=['req'])
 def requirements(ctx, dev=False):

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -135,93 +135,105 @@ class TestFilesPage:
 
         except FileNotFoundError:
             print('An error occurred during rename test!')
-#
+
         finally:
             osf_api.delete_addon_files(session, provider, guid=node_id)
 
     @markers.core_functionality
     def test_checkout_file(self, driver, default_project, session):
-        node_id = default_project.id
-        provider = 'osfstorage'
+        try:
+            node_id = default_project.id
+            provider = 'osfstorage'
 
-        # Connect add-on to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
-        file_name = 'checkout_' + find_current_browser(driver) + '.txt'
-        new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
+            # Connect add-on to node, upload a single test file
+            node = osf_api.get_node(session, node_id=node_id)
+            file_name = 'checkout_' + find_current_browser(driver) + '.txt'
+            new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
 
-        files_page = FilesPage(driver, guid=node_id)
-        files_page.goto()
+            files_page = FilesPage(driver, guid=node_id)
+            files_page.goto()
 
-        row = find_row_by_name(driver, 'osf', new_file)
-        row.click()
-        checkout_button = find_toolbar_button_by_name(driver, 'Check out file')
-        checkout_button.click()
-        # Accept the confirmation modal
-        driver.find_element_by_css_selector('.btn-warning').click()
+            row = find_row_by_name(driver, 'osf', new_file)
+            row.click()
+            checkout_button = find_toolbar_button_by_name(driver, 'Check out file')
+            checkout_button.click()
+            # Accept the confirmation modal
+            driver.find_element_by_css_selector('.btn-warning').click()
 
-        # Wait for delete modal to resolve
-        WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, '.btn-warning')))
-        # Wait for 3rd fangorn row to load
-        WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')))
+            # Wait for delete modal to resolve
+            WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, '.btn-warning')))
+            # Wait for 3rd fangorn row to load
+            WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')))
 
-        # Test that Check Out button is no longer present
-        row = find_row_by_name(driver, 'osf', new_file)
-        row.click()
-        checkout_button = find_toolbar_button_by_name(driver, 'Check out file')
-        assert checkout_button is None
+            # Test that Check Out button is no longer present
+            row = find_row_by_name(driver, 'osf', new_file)
+            row.click()
+            checkout_button = find_toolbar_button_by_name(driver, 'Check out file')
+            assert checkout_button is None
 
-        row = find_row_by_name(driver, 'osf', new_file)
-        row.click()
-        check_in_button = find_toolbar_button_by_name(driver, 'Check in file')
-        check_in_button.click()
+            row = find_row_by_name(driver, 'osf', new_file)
+            row.click()
+            check_in_button = find_toolbar_button_by_name(driver, 'Check in file')
+            check_in_button.click()
 
-        # Wait for page to reload
-        WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')))
-        # Wait for 3rd fangorn row to load
-        WebDriverWait(driver, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')))
+            # Wait for page to reload
+            WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')))
+            # Wait for 3rd fangorn row to load
+            WebDriverWait(driver, 10).until(EC.visibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')))
 
-        # Test that Check In button is no longer present
-        row = find_row_by_name(driver, 'osf', new_file)
-        row.click()
-        check_in_button = find_toolbar_button_by_name(driver, 'Check in file')
-        assert check_in_button is None
+            # Test that Check In button is no longer present
+            row = find_row_by_name(driver, 'osf', new_file)
+            row.click()
+            check_in_button = find_toolbar_button_by_name(driver, 'Check in file')
+            assert check_in_button is None
 
-        osf_api.delete_file(session, metadata['data']['links']['delete'])
+        except FileNotFoundError:
+            print('An error occurred during rename test!')
+
+        finally:
+            osf_api.delete_addon_files(session, provider, guid=node_id)
 
     @markers.core_functionality
     @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
     def test_delete_file(self, driver, default_project, session, provider):
-        node_id = default_project.id
+        try:
+            node_id = default_project.id
 
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
-        if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(session, provider, addon_account_id, node_id=node_id)
+            # Connect addon to node, upload a single test file
+            node = osf_api.get_node(session, node_id=node_id)
+            if provider != 'osfstorage':
+                addon = osf_api.get_user_addon(session, provider)
+                addon_account_id = list(addon['data']['links']['accounts'])[0]
+                osf_api.connect_provider_root_to_node(session, provider, addon_account_id, node_id=node_id)
 
-        file_name = 'delete_' + find_current_browser(driver) + '_' + provider + '.txt'
-        new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
+            file_name = 'delete_' + find_current_browser(driver) + '_' + provider + '.txt'
+            new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
 
-        files_page = FilesPage(driver, guid=node_id)
-        files_page.goto()
+            files_page = FilesPage(driver, guid=node_id)
+            files_page.goto()
 
-        row = find_row_by_name(driver, provider, new_file)
-        row.click()
-        delete_button = find_toolbar_button_by_name(driver, 'Delete')
-        delete_button.click()
+            row = find_row_by_name(driver, provider, new_file)
+            row.click()
+            delete_button = find_toolbar_button_by_name(driver, 'Delete')
+            delete_button.click()
 
-        # Wait for the delete confirmation
-        files_page.delete_modal.present()
+            # Wait for the delete confirmation
+            files_page.delete_modal.present()
 
-        # Front End will show 'delete failed' message - still works as expected
-        driver.find_element_by_css_selector('.btn-danger').click()
+            # Front End will show 'delete failed' message - still works as expected
+            driver.find_element_by_css_selector('.btn-danger').click()
 
-        # Wait for delete modal to resolve
-        WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, 'p[class="text-danger"]')))
+            # Wait for delete modal to resolve
+            WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, 'p[class="text-danger"]')))
 
-        deleted_row = find_row_by_name(driver, provider, new_file)
-        assert deleted_row is None
+            deleted_row = find_row_by_name(driver, provider, new_file)
+            assert deleted_row is None
+
+        except FileNotFoundError:
+            print('An error occurred during rename test!')
+
+        finally:
+            osf_api.delete_addon_files(session, provider, guid=node_id)
 
     @pytest.mark.parametrize('provider, modifier_key, action', [
         ['s3', 'none', 'move'],
@@ -234,130 +246,142 @@ class TestFilesPage:
         ['owncloud', 'alt', 'copy']
     ])
     def test_dragon_drop(self, driver, default_project, session, provider, modifier_key, action):
-        node_id = default_project.id
+        try:
+            node_id = default_project.id
 
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
-        if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(session, provider, addon_account_id, node_id=node_id)
-        if modifier_key == 'alt':
-            file_name = 'copy_' + find_current_browser(driver) + '_' + provider + '.txt'
-            new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
-        else:
-            file_name = 'move_' + find_current_browser(driver) + '_' + provider + '.txt'
-            new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
-
-        files_page = FilesPage(driver, guid=node_id)
-        files_page.goto()
-
-        current_browser = driver.desired_capabilities.get('browserName')
-
-        # Find the row that contains the new file
-        source_row = find_row_by_name(driver, provider, new_file)
-
-        # Find the row with the OSF storage
-        for row in files_page.fangorn_addons:
-            if row.text == 'OSF Storage (United States)':
-                target = row
-                break
-
-        action_chains = ActionChains(driver)
-        action_chains.reset_actions()
-        if 'chrome' in current_browser:
-            # The sleeps in the following code block are needed for
-            # Chrome's virtual keyboard to work properly
+            # Connect addon to node, upload a single test file
+            node = osf_api.get_node(session, node_id=node_id)
+            if provider != 'osfstorage':
+                addon = osf_api.get_user_addon(session, provider)
+                addon_account_id = list(addon['data']['links']['accounts'])[0]
+                osf_api.connect_provider_root_to_node(session, provider, addon_account_id, node_id=node_id)
             if modifier_key == 'alt':
-                action_chains.key_up(Keys.LEFT_ALT).perform()
-                action_chains.key_down(Keys.LEFT_ALT).perform()
-                action_chains.click_and_hold(source_row).perform()
-                time.sleep(1)
+                file_name = 'copy_' + find_current_browser(driver) + '_' + provider + '.txt'
+                new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
+            else:
+                file_name = 'move_' + find_current_browser(driver) + '_' + provider + '.txt'
+                new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
 
-                action_chains.reset_actions()
-                action_chains.move_to_element(target).perform()
-                time.sleep(1)
+            files_page = FilesPage(driver, guid=node_id)
+            files_page.goto()
 
-                action_chains.reset_actions()
-                action_chains.key_up(Keys.LEFT_ALT).perform()
-                action_chains.key_down(Keys.LEFT_ALT).perform()
-                action_chains.key_up(Keys.ALT).perform()
-                action_chains.key_down(Keys.ALT).perform()
-                action_chains.release(target).perform()
-                time.sleep(1)
+            current_browser = driver.desired_capabilities.get('browserName')
 
-                action_chains.reset_actions()
-                action_chains.key_up(Keys.LEFT_ALT).perform()
-                action_chains.key_up(Keys.ALT).perform()
+            # Find the row that contains the new file
+            source_row = find_row_by_name(driver, provider, new_file)
+
+            # Find the row with the OSF storage
+            for row in files_page.fangorn_addons:
+                if row.text == 'OSF Storage (United States)':
+                    target = row
+                    break
+
+            action_chains = ActionChains(driver)
+            action_chains.reset_actions()
+            if 'chrome' in current_browser:
+                # The sleeps in the following code block are needed for
+                # Chrome's virtual keyboard to work properly
+                if modifier_key == 'alt':
+                    action_chains.key_up(Keys.LEFT_ALT).perform()
+                    action_chains.key_down(Keys.LEFT_ALT).perform()
+                    action_chains.click_and_hold(source_row).perform()
+                    time.sleep(1)
+
+                    action_chains.reset_actions()
+                    action_chains.move_to_element(target).perform()
+                    time.sleep(1)
+
+                    action_chains.reset_actions()
+                    action_chains.key_up(Keys.LEFT_ALT).perform()
+                    action_chains.key_down(Keys.LEFT_ALT).perform()
+                    action_chains.key_up(Keys.ALT).perform()
+                    action_chains.key_down(Keys.ALT).perform()
+                    action_chains.release(target).perform()
+                    time.sleep(1)
+
+                    action_chains.reset_actions()
+                    action_chains.key_up(Keys.LEFT_ALT).perform()
+                    action_chains.key_up(Keys.ALT).perform()
+
+                else:
+                    action_chains.click_and_hold(source_row).perform()
+                    # Chrome -> will highlight multiple rows if you do not sleep here
+                    time.sleep(1)
+                    action_chains.move_to_element(target).perform()
+
+                    action_chains.reset_actions()
+                    action_chains.release(target).perform()
+            else:
+                if modifier_key == 'alt':
+                    action_chains.key_down(Keys.LEFT_ALT)
+                    action_chains.click_and_hold(source_row)
+                    action_chains.move_to_element(target)
+                    action_chains.release(target)
+                    action_chains.key_up(Keys.LEFT_ALT)
+                    action_chains.perform()
+                else:
+                    action_chains.drag_and_drop(source_row, target).perform()
+
+            # Wait for 5 seconds for Copying message to show
+            WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.CLASS_NAME, 'text-muted')))
+            # Wait a maximum of 20 seconds for Copying message to resolve
+            WebDriverWait(driver, 20).until(EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted')))
+
+            files_page.goto()
+            origin_file = find_row_by_name(driver, provider, new_file)
+            destination_file = find_row_by_name(driver, 'osf', new_file)
+
+            if modifier_key == 'alt':
+                # Test for copy
+                assert 'copy' in origin_file.text
+                assert 'copy' in destination_file.text
+
+                osf_api.delete_file(session, metadata['data']['links']['delete'])
 
             else:
-                action_chains.click_and_hold(source_row).perform()
-                # Chrome -> will highlight multiple rows if you do not sleep here
-                time.sleep(1)
-                action_chains.move_to_element(target).perform()
+                # Test for move
+                assert origin_file is None
+                assert 'move' in destination_file.text
+        except FileNotFoundError:
+            print('An error occurred during rename test!')
 
-                action_chains.reset_actions()
-                action_chains.release(target).perform()
-        else:
-            if modifier_key == 'alt':
-                action_chains.key_down(Keys.LEFT_ALT)
-                action_chains.click_and_hold(source_row)
-                action_chains.move_to_element(target)
-                action_chains.release(target)
-                action_chains.key_up(Keys.LEFT_ALT)
-                action_chains.perform()
-            else:
-                action_chains.drag_and_drop(source_row, target).perform()
-
-        # Wait for 5 seconds for Copying message to show
-        WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.CLASS_NAME, 'text-muted')))
-        # Wait a maximum of 20 seconds for Copying message to resolve
-        WebDriverWait(driver, 20).until(EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted')))
-
-        files_page.goto()
-        origin_file = find_row_by_name(driver, provider, new_file)
-        destination_file = find_row_by_name(driver, 'osf', new_file)
-
-        if modifier_key == 'alt':
-            # Test for copy
-            assert 'copy' in origin_file.text
-            assert 'copy' in destination_file.text
-
-            osf_api.delete_file(session, metadata['data']['links']['delete'])
-
-        else:
-            # Test for move
-            assert origin_file is None
-            assert 'move' in destination_file.text
+        finally:
+            osf_api.delete_addon_files(session, provider, guid=node_id)
 
     @pytest.mark.skipif(settings.DRIVER == 'remote', reason='File_Detector Class only ')
     @pytest.mark.parametrize('provider', ['s3', 'dropbox', 'box', 'owncloud'])
     def test_download_file(self, driver, default_project, session, provider):
-        node_id = default_project.id
+        try:
+            node_id = default_project.id
 
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
-        if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(session, provider, addon_account_id, node_id=node_id)
+            # Connect addon to node, upload a single test file
+            node = osf_api.get_node(session, node_id=node_id)
+            if provider != 'osfstorage':
+                addon = osf_api.get_user_addon(session, provider)
+                addon_account_id = list(addon['data']['links']['accounts'])[0]
+                osf_api.connect_provider_root_to_node(session, provider, addon_account_id, node_id=node_id)
 
-        file_name = 'download_' + find_current_browser(driver) + '_' + provider + '.txt'
-        new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
+            file_name = 'download_' + find_current_browser(driver) + '_' + provider + '.txt'
+            new_file, metadata = osf_api.upload_fake_file(session=session, node=node, name=file_name, provider=provider)
 
-        files_page = FilesPage(driver, guid=node_id)
-        files_page.goto()
+            files_page = FilesPage(driver, guid=node_id)
+            files_page.goto()
 
-        row = find_row_by_name(driver, provider, new_file)
-        row.click()
-        download_button = find_toolbar_button_by_name(driver, 'Download')
-        download_button.click()
-        # Wait to see if error message appears -- for negative test
-        time.sleep(2)
+            row = find_row_by_name(driver, provider, new_file)
+            row.click()
+            download_button = find_toolbar_button_by_name(driver, 'Download')
+            download_button.click()
+            # Wait to see if error message appears -- for negative test
+            time.sleep(2)
 
-        # Negative test
-        assert 'Could not retrieve file or directory' not in driver.find_element_by_xpath('/html/body').text
-        osf_api.delete_file(session, metadata['data']['links']['delete'])
+            # Negative test
+            assert 'Could not retrieve file or directory' not in driver.find_element_by_xpath('/html/body').text
+
+        except FileNotFoundError:
+            print('An error occurred during rename test!')
+
+        finally:
+            osf_api.delete_addon_files(session, provider, guid=node_id)
 
 
 '''


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our add-ons files test leaves behind test files if it fails before the delete step. In this PR we will implement a try/except statement to ensure files are being cleaned up regardless if the test passes or fails. 

## Summary of Changes
1 - Apply try/finally statement to each test 
2 - Create osf_api.py delete function to delete all files specific to that browser & add-on
3 - Refactor get_current browser code
4 - Move setup code outside of try block

## Reviewer's Actions
Fetch a new local branch
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/90/head:fix/feature/project-files`
Run this test using:
`pytest tests/test_project_files.py -s -v`

- Here is my project used for managing the add-ons used during this test https://staging.osf.io/tzpgu/

## Testing Changes Moving Forward
To relieve processing power from the test.osf.io database, we could modify our tests so that test_project_files.py does not run in parallel across multiple browsers. 


## Ticket

https://openscience.atlassian.net/browse/ENG-1396
