### PR TITLE
Fix/quickfiles

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -57,16 +57,27 @@ def get_user_addon(session, provider, user=None):
 
 
 def upload_single_quickfile(session):
-
-    """Upload a file to the current user's quickfiles if one is not already uploaded.
-    Return the name of the file or none if one wasn't uploaded.
+    """Upload a new quickfile. Delete existing quickfiles first.
+    Note: Currently using v2.0 of the API. Certain lines will need to be changed on update.
+    TODO: Make this more general.
     """
+
     user = current_user(session)
     quickfiles_url = user.relationships.quickfiles['links']['related']['href']
+    delete_all_quickfiles(session, quickfiles_url)
 
-    if session.get(quickfiles_url)['links']['meta']['total'] < 1:
-        upload_url = user.relationships.quickfiles['links']['upload']['href']
-        return upload_fake_file(session, upload_url=upload_url)
+    upload_url = user.relationships.quickfiles['links']['upload']['href']
+    return upload_fake_file(session, upload_url=upload_url, quickfile=True)
+
+
+def delete_all_quickfiles(session, quickfiles_url):
+    """ Delete all quickfiles. Just pass in the quickfiles url for the currently logged in user.
+    """
+
+    for quickfile in session.get(quickfiles_url)['data']:
+        delete_url = quickfile['links']['delete']
+        delete_file(session, delete_url)
+
 
 def get_all_institutions(session):
     url = '/v2/institutions/'

--- a/tests/test_quickfiles.py
+++ b/tests/test_quickfiles.py
@@ -101,6 +101,7 @@ class AnothersQuickfilesMixin:
 
         # assert anothers_quickfiles.download_as_zip_button.absent()
 
+
 @markers.dont_run_on_prod
 class TestQuickfilesLoggedOut(AnothersQuickfilesMixin):
 
@@ -108,6 +109,7 @@ class TestQuickfilesLoggedOut(AnothersQuickfilesMixin):
     def anothers_quickfiles(self, quickfiles_page):
         quickfiles_page.goto()
         return quickfiles_page
+
 
 @markers.dont_run_on_prod
 class TestQuickfilesAsDifferentUser(AnothersQuickfilesMixin):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Broken quickfiles are being generated by the api. Why? By default, the api does not assign a guid to a quickfile. Therefore, we must add an intermediate step (before viewing the file on the front end) to use the query parameter `/?create_guid=1` . This step allows the quickfile to be tested properly on the front end. 
The cleanup portion of this code has also been updated to always delete quickfiles at the start of each test run - ensuring end to end coverage. 


## Summary of Changes
1 - Add an intermediate step for api to generate a guid for test quickfiles
2 - Refactor code to delete old quickfiles
3 - Update docstrings & readability

## Reviewer's Actions

`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/91/head:fix/quickfiles`
Run this test using
`tests/test_quickfiles.py -s -v`

## Testing Changes Moving Forward
In the future, we can uncomment some of the test assertions and test more file actions on the front end. This will likely have to wait until quickfiles is 'emberized'. 

We can also look into applying a post-delete as opposed to a pre-delete implemented in this pull request. There are pros and cons to both but starting each test with a clean slate seems to be the best way for now. 


## Ticket

https://openscience.atlassian.net/browse/ENG-1607
