### PR TITLE
Feature/service providers

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -266,6 +266,14 @@ def get_provider_submission_status(provider):
     return provider['attributes']['allow_submissions']
 
 
+def get_providers_total(provider_name, session):
+    """ Return the total number of preprints for a given service provider.
+        Note: Reformat provider names to all lowercase and remove white spaces.
+    """
+    provider_url = '/v2/providers/preprints/{}/preprints/'.format(provider_name.lower().replace(' ', ''))
+    return session.get(provider_url)['links']['meta']['total']
+
+
 def connect_provider_root_to_node(
     session, provider, external_account_id,
     node_id=settings.PREFERRED_NODE,

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -52,6 +52,7 @@ class PreprintLandingPage(BasePreprintPage):
     submit_navbar = Locator(By.CSS_SELECTOR, '.branded-nav > :nth-child(2)')
     submit_button = Locator(By.CSS_SELECTOR, '.btn.btn-success')
 
+
 class PreprintSubmitPage(BasePreprintPage):
     url_addition = 'submit'
 
@@ -85,6 +86,7 @@ class PreprintSubmitPage(BasePreprintPage):
     create_preprint_button = Locator(By.CSS_SELECTOR, '.preprint-submit-body .submit-section > div > button.btn.btn-success.btn-md.m-t-md.pull-right')
     modal_create_preprint_button = Locator(By.CSS_SELECTOR, '.modal-footer button.btn-success:nth-child(2)', settings.LONG_TIMEOUT)
 
+
 @pytest.mark.usefixtures('must_be_logged_in')
 class PreprintDiscoverPage(BasePreprintPage):
     url_addition = 'discover'
@@ -94,6 +96,7 @@ class PreprintDiscoverPage(BasePreprintPage):
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '.search-result h4 > a')
+    no_results = GroupLocator(By.CSS_SELECTOR, '.search-results-section .text-muted')
 
 
 class PreprintDetailPage(GuidBasePage, BasePreprintPage):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -135,12 +135,15 @@ class TestBrandedProviders:
     def test_detail_page(self, session, driver, provider):
         """Test a preprint detail page by grabbing the first search result from the discover page.
         """
+        discover_page = PreprintDiscoverPage(driver, provider=provider)
+        discover_page.goto()
+        discover_page.verify()
+        discover_page.loading_indicator.here_then_gone()
+
         if osf_api.get_providers_total(provider['attributes']['name'], session=session):
-            discover_page = PreprintDiscoverPage(driver, provider=provider)
-            discover_page.goto()
-            discover_page.verify()
-            discover_page.loading_indicator.here_then_gone()
             search_results = discover_page.search_results
             assert search_results
             search_results[0].click()
             PreprintDetailPage(driver, verify=True)
+        else:
+            assert discover_page.no_results

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -132,13 +132,15 @@ class TestBrandedProviders:
     @markers.smoke_test
     @markers.core_functionality
     @pytest.mark.skipif(not settings.PRODUCTION, reason='Cannot test on stagings as they share SHARE')
-    def test_detail_page(self, driver, provider):
+    def test_detail_page(self, session, driver, provider):
         """Test a preprint detail page by grabbing the first search result from the discover page.
         """
-        discover_page = PreprintDiscoverPage(driver, provider=provider)
-        discover_page.goto()
-        discover_page.loading_indicator.here_then_gone()
-        search_results = discover_page.search_results
-        assert search_results
-        search_results[0].click()
-        PreprintDetailPage(driver, verify=True)
+        if osf_api.get_providers_total(provider['attributes']['name'], session=session):
+            discover_page = PreprintDiscoverPage(driver, provider=provider)
+            discover_page.goto()
+            discover_page.verify()
+            discover_page.loading_indicator.here_then_gone()
+            search_results = discover_page.search_results
+            assert search_results
+            search_results[0].click()
+            PreprintDetailPage(driver, verify=True)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Biohackr Archive does not have any preprints and is causing our selenium test to fail. Previously, our tests assumed that each provider had at least 1 submission. Our test checks the search results page and assumes `no search results found` is an error. 

In this PR, we queried the API to see if a given service provider has 1 or more preprints. If the provider has 0 preprints, check for empty search results. If the provider has at least 1 preprint, continue as normal. 

## Summary of Changes
1 - Skip assertion for preprint providers with no content
2 - Assert 'No content' text is present on the search results page

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/93/head:feature/service-providers`

Run this test locally using
`tests/preprints.py -s -v`

Update selenium env. variables
`DOMAIN=prod`
`USER_ONE=_LeemusSteinert_`
`USER_ONE_PASSWORD=_LeemusPassword_`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-1423
