### PR TITLE
Skip My Projects page test using pytest markers

### DIFF
--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -17,6 +17,7 @@ def my_projects_page(driver):
     return my_projects_page
 
 
+@pytest.mark.skip(reason='Skip this test until bug ticket ENG-1737 is resolved')
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestMyProjectsPage:
     """ Custom collections must implement a PRE-delete setup to start in a clean state.


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our test suite has encountered a bug with the My Projects page. We've documented the bug and linked the JIRA ticket below. In the meantime, we would like to skip the test to remove unhelpful failures during our test runs and improve the overall stability of our test suite. See linked ticket for more information. 


## Summary of Changes
Use pytest's built in markers to temporarily skip the `My Projects page` test.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/96/head:bug/my-projects-page`

Run this test locally using
`pytest tests/test_my_projects.py -s -v`

## Testing Changes Moving Forward
This action will be reversed once the linked ticket is resolved.


## Related Ticket
https://openscience.atlassian.net/browse/ENG-1737