### PR TITLE
travis: don't run develop tests on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,11 @@ jobs:
     env: TEST_BUILD='chrome'
     script: invoke test_travis_part_one
   -  # stage part one
+    if: branch != master
     env: TEST_BUILD='firefox'
     script: invoke test_travis_part_one
   -  # stage part one
+    if: branch != master
     env: TEST_BUILD='edge'
     script: invoke test_travis_part_one
   - stage: Staging tests part two
@@ -50,8 +52,10 @@ jobs:
     env: TEST_BUILD='chrome'
     script: invoke test_travis_part_two
   -  # stage part two
+    if: branch != master
     env: TEST_BUILD='firefox'
     script: invoke test_travis_part_two
   -  # stage part two
+    if: branch != master
     env: TEST_BUILD='edge'
     script: invoke test_travis_part_two


### PR DESCRIPTION
# DUMMY PR

 * Stop running non-smoke tests for firefox and edge when branch is
   `master`.  The chrome jobs were protected with `if` tests, but they
   were omitted for the other two browsers.


<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose



## Summary of Changes



## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`

Run this test using
`tests/<name_of_test>.py -s -v`

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-
