### PR TITLE
Browserstack Edge update

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -100,10 +100,6 @@ caps = {
     'chrome': {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'edge': {'browser': 'Edge', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'firefox': {'browser': 'Firefox', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
-    'android': {'device': 'Samsung Galaxy S8', 'realMobile': 'true', 'os_version': '7.0'},
-    'ios': {'device': 'iPhone 7', 'realMobile': 'true', 'os_version': '10.0'},
-    'safari': {'browser': 'Safari', 'browser_version': '10.1', 'os': 'OS X', 'os_version': 'Sierra',
-               'safari.options': {'technologyPreview': 'true'}}
 }
 
 BUILD = DRIVER

--- a/settings.py
+++ b/settings.py
@@ -97,8 +97,7 @@ CUSTOM_INSTITUTION_DOMAINS = domains[DOMAIN]['custom_institution_domains']
 
 # Browser capabilities for browserstack testing
 caps = {
-    'chrome':
-        {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
+    'chrome': {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'edge': {'browser': 'Edge', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536', 'browser_version': '17.0'},
     'firefox': {'browser': 'Firefox', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'android': {'device': 'Samsung Galaxy S8', 'realMobile': 'true', 'os_version': '7.0'},

--- a/settings.py
+++ b/settings.py
@@ -98,7 +98,7 @@ CUSTOM_INSTITUTION_DOMAINS = domains[DOMAIN]['custom_institution_domains']
 # Browser capabilities for browserstack testing
 caps = {
     'chrome': {'browser': 'Chrome', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
-    'edge': {'browser': 'Edge', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536', 'browser_version': '17.0'},
+    'edge': {'browser': 'Edge', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'firefox': {'browser': 'Firefox', 'os': 'Windows', 'os_version': '10', 'resolution': '2048x1536'},
     'android': {'device': 'Samsung Galaxy S8', 'realMobile': 'true', 'os_version': '7.0'},
     'ios': {'device': 'iPhone 7', 'realMobile': 'true', 'os_version': '10.0'},


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our test were initially set up to run using Edge version 17.0. After investigating edge-specific failures on Travis jobs, we found out that Edge versions 17.0 and 18.0 are no longer suited for running our test suite. We've updated to the latest stable version of Edge in `settings.py`


## Summary of Changes

1 - Update browserstack's virtual browser from `Edge 17.0` to the latest stable version by removing `browser_version` variable
2 - Remove unused browsers


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/103/head:feature/dashboard`

Run this test using
Modify your environment file
`DRIVER=Remote`
`TEST_BUILD=edge`
`BSTACK_USER=username`
`BSTACK_KEY=password`

For testing on production, also use
`DOMAIN=prod`
`PREFERRED_NODE=ra4bf`
`USER_ONE=Leemus_email`
`USER_ONE_PASSWORD=Leemus_pass`

`tests/test_dashboard.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-1750
