### PR TITLE
Preprints/conflict of interest

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -80,6 +80,9 @@ class PreprintSubmitPage(BasePreprintPage):
 
     authors_save_button = Locator(By.CSS_SELECTOR, '#preprint-form-authors .btn-primary', settings.QUICK_TIMEOUT)
 
+    conflict_of_interest = Locator(By.ID, 'coiNo', settings.QUICK_TIMEOUT)
+    coi_save_button = Locator(By.CSS_SELECTOR, '#author-coi-assertion .btn-primary')
+
     supplemental_create_new_project = Locator(By.CSS_SELECTOR, 'div[class="start"] > div[class="row"] > div:nth-child(2)', settings.QUICK_TIMEOUT)
     supplemental_save_button = Locator(By.CSS_SELECTOR, '#supplemental-materials .btn-primary')
 

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -107,4 +107,4 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
-    supplemental_link = Locator(By.CSS_SELECTOR, 'h6[class="detail-header-info"] > div:last-child > a:last-child')
+    view_page = Locator(By.ID, 'view-page')

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -73,11 +73,6 @@ class TestPreprintWorkflow:
         submit_page.create_preprint_button.click()
         submit_page.modal_create_preprint_button.click()
 
-        current_browser = driver.desired_capabilities.get('browserName')
-        if 'edge' in current_browser:
-            alert = driver.switch_to_alert()
-            alert.accept()
-
         preprint_detail = PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -62,6 +62,9 @@ class TestPreprintWorkflow:
         # Wait for authors box to show
         submit_page.authors_save_button.click()
 
+        submit_page.conflict_of_interest.click()
+        submit_page.coi_save_button.click()
+
         # Wait for Supplemental materials to show
         submit_page.supplemental_create_new_project.click()
         submit_page.supplemental_save_button.click()

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -2,6 +2,7 @@ import pytest
 import markers
 import settings
 import logging
+import re
 
 from api import osf_api
 from selenium.webdriver.support.ui import WebDriverWait
@@ -81,9 +82,11 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
 
         assert preprint_detail.title.text == project_with_file.title
+        match = re.search(r'Supplemental Materials\s+test\.osf\.io/([a-z0-9]{5})', preprint_detail.view_page.text)
+        assert match is not None
 
         # Delete supplemental project created during workflow
-        supplemental_guid = preprint_detail.supplemental_link.text[12:17]
+        supplemental_guid = match.group(1)
         osf_api.delete_project(session, supplemental_guid, None)
 
     @markers.smoke_test


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our development team has added `Conflict of Interest` to the preprints workflow. We need to update our selenium tests to account for changes on the front end. 


## Summary of Changes
1 - Add locators for Conflict of Interest
2 - Update supplemental materials link locator
3 - Use Regex group to retrieve supplemental material node guid
4 - Remove outdated code


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/105/head:preprints/conflict-of-interest`

Run this test using
`tests/preprints.py::TestPreprintWorkflow::test_create_preprint_from_landing -s -v`


## Testing Changes Moving Forward
This feature update is only 1 of 3 Author Assertions. We will add the other updates in upcoming tickets.
Public Data: https://openscience.atlassian.net/browse/ENG-1801
Preregistration: https://openscience.atlassian.net/browse/ENG-1808

## Ticket

https://openscience.atlassian.net/browse/ENG-1789
