### PR TITLE
Feature/donate page

### DIFF
--- a/pages/cos.py
+++ b/pages/cos.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 
 
 class COSDonatePage(BasePage):
-    url = 'https://cos.io/about/support-cos/'
+    url = 'https://www.cos.io/support'
 
     identity = Locator(By.CSS_SELECTOR, 'div[class="slide-wrapper-background"]', settings.LONG_TIMEOUT)
     page_heading = Locator(By.CSS_SELECTOR, 'div[class="banner-element"]')

--- a/pages/cos.py
+++ b/pages/cos.py
@@ -8,5 +8,7 @@ from selenium.webdriver.common.by import By
 class COSDonatePage(BasePage):
     url = 'https://www.cos.io/support'
 
-    identity = Locator(By.CSS_SELECTOR, 'div[class="slide-wrapper-background"]', settings.LONG_TIMEOUT)
+    # This meta tag is unique to the donate page but cannot be verified as a 'visible' locator
+    # See https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L157-L163
+    identity = Locator(By.XPATH, '//meta[@name="cos:id" and @content="donate-page"]', settings.LONG_TIMEOUT)
     page_heading = Locator(By.CSS_SELECTOR, 'div[class="banner-element"]')

--- a/pages/cos.py
+++ b/pages/cos.py
@@ -11,4 +11,3 @@ class COSDonatePage(BasePage):
     # This meta tag is unique to the donate page but cannot be verified as a 'visible' locator
     # See https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L157-L163
     identity = Locator(By.XPATH, '//meta[@name="cos:id" and @content="donate-page"]', settings.LONG_TIMEOUT)
-    page_heading = Locator(By.CSS_SELECTOR, 'div[class="banner-element"]')

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -119,9 +119,7 @@ class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
     def test_donate_link(self, page, driver):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
-        assert driver.current_url == donate_page.url
-        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('name') == 'cos:id'
-        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('content') == 'donate-page'
+        assert_donate_page(driver, donate_page)
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()
@@ -203,9 +201,7 @@ class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
     def test_donate_link(self, page, driver):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
-        assert driver.current_url == donate_page.url
-        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('name') == 'cos:id'
-        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('content') == 'donate-page'
+        assert_donate_page(driver, donate_page)
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()
@@ -258,3 +254,13 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
         page = RegistriesLandingPage(driver)
         page.goto()
         return page
+
+
+def assert_donate_page(driver, donate_page):
+    # locators.py does not currently support invisible elements as identity
+    # https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L151
+    meta_tag = driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]')
+
+    assert driver.current_url == donate_page.url
+    assert meta_tag.get_attribute('name') == 'cos:id'
+    assert meta_tag.get_attribute('content') == 'donate-page'

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -118,7 +118,8 @@ class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
 
     def test_donate_link(self, page, driver):
         page.navbar.donate_link.click()
-        COSDonatePage(driver, verify=True)
+        donate_page = COSDonatePage(driver, verify=False)
+        assert driver.current_url == donate_page.url
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()
@@ -199,7 +200,8 @@ class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
 
     def test_donate_link(self, page, driver):
         page.navbar.donate_link.click()
-        COSDonatePage(driver, verify=True)
+        donate_page = COSDonatePage(driver, verify=False)
+        assert driver.current_url == donate_page.url
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -120,6 +120,8 @@ class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
         assert driver.current_url == donate_page.url
+        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('name') == 'cos:id'
+        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('content') == 'donate-page'
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()
@@ -202,6 +204,8 @@ class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
         assert driver.current_url == donate_page.url
+        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('name') == 'cos:id'
+        assert driver.find_element_by_xpath('//meta[@name="cos:id" and @content="donate-page"]').get_attribute('content') == 'donate-page'
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Although the donate page (https://www.cos.io/support) is not part of the OSF, we still navigate to it using the `navbars.py` test. Since this page is subject to change based on metascience feedback, we will be using meta tags to and the URL to verify our tests have landed on the correct page. 


## Summary of Changes
1 - Verify donate page using url
2 - Verify donate page using meta tag
3 - Make donate test assertions modular
4 - Remove `page_heading` locator


## Reviewer's Actions
`git fetch <remote> pull/107/head:feature/donate-page`


Run this test using
`pytest tests/test_navbar.py::TestOSFHomeNavbar::test_donate_link -s -v`
`pytest tests/test_navbar.py::TestMeetingsNavbar::test_donate_link -s -v`


## Testing Changes Moving Forward
Selenium Navbars epic includes the following upgrades:

1. [Quickfiles](https://openscience.atlassian.net/browse/ENG-857)
2. [Institutions](https://openscience.atlassian.net/browse/ENG-858)
3. [Registries](https://openscience.atlassian.net/browse/ENG-1127)
4. [Preprints](https://openscience.atlassian.net/browse/ENG-1126)

## Ticket

https://openscience.atlassian.net/browse/ENG-1858
