### PR TITLE
Update Donate Link

### DIFF
--- a/pages/cos.py
+++ b/pages/cos.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 
 
 class COSDonatePage(BasePage):
-    url = 'https://www.cos.io/support'
+    url = 'https://www.cos.io/about/support-cos'
 
     # This meta tag is unique to the donate page but cannot be verified as a 'visible' locator
     # See https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L157-L163


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Due to recent changes with pathways and Hubspot, the donate page url has been updated. Our selenium tests are now updated to match the correct url on production. https://www.cos.io/about/support-cos


## Summary of Changes
1 - Update the Donate Link URL


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/112/head:feature/donate-page`

Run this test using
`tests/<name_of_test>.py -s -v`
`pytest tests/test_navbar.py::TestMeetingsNavbar::test_donate_link -s -v`
`pytest tests/test_navbar.py::TestOSFHomeNavbar::test_donate_link -s -v`

## Testing Changes Moving Forward
A note for future improvement and for thinking about how our selenium tests take care of legacy URLs. In this example, given that we have the legacy URL https://www.cos.io/support and the new URL https://www.cos.io/about/support-cos, is it selenium tests' job to test legacy URL redirection? This is an open question. My thought is NO (for now) since 1) it does not include any user action that needs to be automated and 2) it can be tested more easily by other means.

## Ticket

https://openscience.atlassian.net/browse/ENG-2004
