### PR TITLE
Feature/author assertions

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -68,6 +68,13 @@ class PreprintSubmitPage(BasePreprintPage):
     upload_select_file = Locator(By.CSS_SELECTOR, '.file-browser-item > a:nth-child(2)')
     upload_file_save_continue = Locator(By.CSS_SELECTOR, 'div[class="p-t-xs pull-right"] > button[class="btn btn-primary"]')
 
+    # Author Assertions
+    public_available_button = Locator(By.ID, 'hasDataLinksAvailable', settings.QUICK_TIMEOUT)
+    public_data_input = Locator(By.CSS_SELECTOR, 'div[data-test-multiple-textbox-index] > input')
+    preregistration_no_button = Locator(By.ID, 'hasPreregLinksNo')
+    preregistration_input = Locator(By.NAME, 'whyNoPrereg')
+    save_author_assertions = Locator(By.CSS_SELECTOR, 'button[data-test-author-assertions-continue]')
+
     basics_license_dropdown = Locator(By.CSS_SELECTOR, 'select[class="form-control"]', settings.LONG_TIMEOUT)
     basics_universal_license = Locator(By.CSS_SELECTOR, 'select[class="form-control"] > option:nth-child(3)', settings.QUICK_TIMEOUT)
     basics_tags_section = Locator(By.CSS_SELECTOR, '#preprint-form-basics .tagsinput')

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -70,10 +70,10 @@ class PreprintSubmitPage(BasePreprintPage):
 
     # Author Assertions
     public_available_button = Locator(By.ID, 'hasDataLinksAvailable', settings.QUICK_TIMEOUT)
-    public_data_input = Locator(By.CSS_SELECTOR, 'div[data-test-multiple-textbox-index] > input')
+    public_data_input = Locator(By.CSS_SELECTOR, '[data-test-multiple-textbox-index] > input')
     preregistration_no_button = Locator(By.ID, 'hasPreregLinksNo')
     preregistration_input = Locator(By.NAME, 'whyNoPrereg')
-    save_author_assertions = Locator(By.CSS_SELECTOR, 'button[data-test-author-assertions-continue]')
+    save_author_assertions = Locator(By.CSS_SELECTOR, '[data-test-author-assertions-continue]')
 
     basics_license_dropdown = Locator(By.CSS_SELECTOR, 'select[class="form-control"]', settings.LONG_TIMEOUT)
     basics_universal_license = Locator(By.CSS_SELECTOR, 'select[class="form-control"] > option:nth-child(3)', settings.QUICK_TIMEOUT)
@@ -88,7 +88,7 @@ class PreprintSubmitPage(BasePreprintPage):
     authors_save_button = Locator(By.CSS_SELECTOR, '#preprint-form-authors .btn-primary', settings.QUICK_TIMEOUT)
 
     conflict_of_interest = Locator(By.ID, 'coiNo', settings.QUICK_TIMEOUT)
-    coi_save_button = Locator(By.CSS_SELECTOR, '#author-coi-assertion .btn-primary')
+    coi_save_button = Locator(By.CSS_SELECTOR, '[data-test-coi-continue]')
 
     supplemental_create_new_project = Locator(By.CSS_SELECTOR, 'div[class="start"] > div[class="row"] > div:nth-child(2)', settings.QUICK_TIMEOUT)
     supplemental_save_button = Locator(By.CSS_SELECTOR, '#supplemental-materials .btn-primary')

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -48,6 +48,15 @@ class TestPreprintWorkflow:
         submit_page.upload_select_file.click()
         submit_page.upload_file_save_continue.click()
 
+        # Author assertions
+        submit_page.public_available_button.click()
+        submit_page.public_data_input.click()
+        submit_page.public_data_input.send_keys_deliberately('https://osf.io/')
+        submit_page.preregistration_no_button.click()
+        submit_page.preregistration_input.click()
+        submit_page.preregistration_input.send_keys_deliberately('QA Testing')
+        submit_page.save_author_assertions.click()
+
         submit_page.basics_license_dropdown.click()
         submit_page.basics_universal_license.click()
         submit_page.basics_tags_section.click()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
The front end team has implemented author assertions for preprints. We will update our selenium suite to test public data and preregistration assertions. 

## Summary of Changes
1 - Add `Public Data` test
2 - Add `Preregistration` test
3 - Update conflict of interest locator

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`
`git fetch <remote> pull/114/head:feature/author-assertions`

Run this test using
`pytest tests/test_preprints.py::TestPreprintWorkflow::test_create_preprint_from_landing -s -v`

## Testing Changes Moving Forward
Verify the newly added author assertions on the preprint overview page. 
JIRA Ticket: https://openscience.atlassian.net/browse/ENG-2022

## Tickets
https://openscience.atlassian.net/browse/ENG-1801
https://openscience.atlassian.net/browse/ENG-1808
