### PR TITLE
Add search query to Firefox search results

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 from api import osf_api
+from utils import find_current_browser
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -16,10 +17,6 @@ from pages.preprints import (
 )
 
 logger = logging.getLogger(__name__)
-
-def find_current_browser(driver):
-    current_browser = driver.desired_capabilities.get('browserName')
-    return current_browser
 
 @pytest.fixture
 def landing_page(driver):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -17,6 +17,9 @@ from pages.preprints import (
 
 logger = logging.getLogger(__name__)
 
+def find_current_browser(driver):
+    current_browser = driver.desired_capabilities.get('browserName')
+    return current_browser
 
 @pytest.fixture
 def landing_page(driver):
@@ -138,6 +141,11 @@ class TestBrandedProviders:
         """Test a preprint detail page by grabbing the first search result from the discover page.
         """
         discover_page = PreprintDiscoverPage(driver, provider=provider)
+
+        # This fails only in firefox because of selenium incompatibilities with right-left languages
+        if 'firefox' in find_current_browser(driver) and 'arabixiv' in provider['id']:
+            discover_page.url_addition += '?q=Analysis'
+
         discover_page.goto()
         discover_page.verify()
         discover_page.loading_indicator.here_then_gone()

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -5,6 +5,7 @@ import settings
 
 from api import osf_api
 from pages.project import FilesPage
+from utils import find_current_browser
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
@@ -75,11 +76,6 @@ def find_toolbar_button_by_name(driver, button_name):
         if button.text == button_name:
             return button
     return
-
-
-def find_current_browser(driver):
-    current_browser = driver.desired_capabilities.get('browserName')
-    return current_browser
 
 
 @markers.dont_run_on_prod

--- a/utils.py
+++ b/utils.py
@@ -71,3 +71,8 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
 
     driver.maximize_window()
     return driver
+
+
+def find_current_browser(driver):
+    current_browser = driver.desired_capabilities.get('browserName')
+    return current_browser


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Selenium cannot detect the first search result of the Arabixiv preprint service **IF** the title is written in Arabic. This issue only happens in Firefox so Google Chrome and Microsoft Edge will still cover the default test case. Our goal is use an English-titled preprint in Firefox which can be done by searching for the term "Analysis" in the URL. 


## Summary of Changes

1. Check browser for Firefox and Arabixiv preprint service
2. Search for the term "Analysis" and continue test normally

## Reviewer's Actions
`git fetch <remote> pull/115/head:feature/arabixiv`

Run this test using
`pytest tests/test_preprints.py::TestBrandedProviders::test_detail_page -s -v`

## Testing Changes Moving Forward
N/A 

## Ticket

https://openscience.atlassian.net/browse/ENG-1800
