### PR TITLE
Feature/registries search

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -18,7 +18,8 @@ class RegistriesLandingPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries'
 
     identity = Locator(By.CSS_SELECTOR, '._RegistriesHeader_3zbd8x', settings.LONG_TIMEOUT)
-    search_button = Locator(By.CSS_SELECTOR, '[data-test-search-button]')
+    search_box = Locator(By.ID, 'search')
+
 
 class RegistriesDiscoverPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries/discover'

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -14,6 +14,7 @@ class BaseRegistriesPage(OSFBasePage):
     # Components
     navbar = ComponentLocator(RegistriesNavbar)
 
+
 class RegistriesLandingPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries'
 
@@ -37,6 +38,7 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
                 result.find_element_by_class_name('label-default')
             except NoSuchElementException:
                 return result.find_element_by_css_selector('[data-test-result-title-id]')
+
 
 class RegistrationDetailPage(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-registration-title]')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -26,6 +26,7 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
 
     identity = Locator(By.CSS_SELECTOR, '[data-test-share-logo]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    osf_filter = Locator(By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]')
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '._RegistriesSearchResult__Title_1wvii8')

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -7,11 +7,13 @@ from pages.registries import (
     RegistrationDetailPage
 )
 
+
 @pytest.fixture
 def landing_page(driver):
     landing_page = RegistriesLandingPage(driver)
     landing_page.goto()
     return landing_page
+
 
 class TestRegistriesDiscoverPage:
     @markers.smoke_test

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -17,7 +17,7 @@ class TestRegistriesDiscoverPage:
     @markers.smoke_test
     @markers.core_functionality
     def test_search_results_exist(self, driver, landing_page):
-        landing_page.search_button.click()
+        landing_page.search_box.send_keys_deliberately('QA Test\n')
         discover_page = RegistriesDiscoverPage(driver, verify=True)
         discover_page.loading_indicator.here_then_gone()
         assert len(discover_page.search_results) > 0

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -31,6 +31,11 @@ class TestRegistriesDiscoverPage:
         discover_page.loading_indicator.here_then_gone()
         search_results = discover_page.search_results
         assert search_results
+
+        discover_page.scroll_into_view(discover_page.osf_filter.element)
+        discover_page.osf_filter.click()
+        discover_page.loading_indicator.here_then_gone()
+
         target_registration = discover_page.get_first_non_withdrawn_registration()
         target_registration_title = target_registration.text
         target_registration.click()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->

## Purpose
OSF Registries has received changes on the front end. We are updating our automated tests to handle the changes.

1. The 'search' button was removed from the registries discover page. Moving forward, we will send an 'enter' key stroke to perform the same operation.
2. There are 2 different registration detail pages with the following url structures:
    - https://osf.io/GUID (original)
    - https://staging-share.osf.io/registration/<registration_id> (SHARE)

## Summary of Changes
1 - Search using '/n', remove button click
2 - Filter for original registration types (non-withdrawn)
3 - Fix Spacing


## Reviewer's Actions
`git fetch <remote> pull/118/head:feature/registries-search`


Run this test using
`tests/test_registries.py -v`


## Testing Changes Moving Forward
Trove updates will provide a better way to search for registrations. We can update our tests as necessary when those changes roll out. 

## Ticket
https://openscience.atlassian.net/browse/ENG-2229