### PR TITLE
Add ENTER key to registries search test

### DIFF
--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,6 +1,8 @@
 import pytest
 import markers
 
+from selenium.webdriver.common.keys import Keys
+
 from pages.registries import (
     RegistriesLandingPage,
     RegistriesDiscoverPage,
@@ -19,7 +21,8 @@ class TestRegistriesDiscoverPage:
     @markers.smoke_test
     @markers.core_functionality
     def test_search_results_exist(self, driver, landing_page):
-        landing_page.search_box.send_keys_deliberately('QA Test\n')
+        landing_page.search_box.send_keys_deliberately('QA Test')
+        landing_page.search_box.send_keys(Keys.ENTER)
         discover_page = RegistriesDiscoverPage(driver, verify=True)
         discover_page.loading_indicator.here_then_gone()
         assert len(discover_page.search_results) > 0


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our browserstack test run shows that our test successfully sends the test string `QA Test` but does not submit the search query. Locally, we were able to achieve the same end result using the ENTER special key. In this PR, we will update the registries search test to explicitly send the ENTER key versus '\n'. 


## Summary of Changes
- Change "QA Test\n" to "QA Test" + ENTER


## Reviewer's Actions
`git fetch <remote> pull/120/head:feature/registries-search`

Run this test using
`tests/test_registries.py::TestRegistriesDiscoverPage::test_search_results_exist -v`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-ENG-2305
